### PR TITLE
Feature: Request source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+sudo: false
+
 php:
   - 5.4
   - 5.5
@@ -14,7 +16,7 @@ matrix:
     - php: nightly
 
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.2.0/setup' -O - | php
+  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.4.0/setup' -O - | php
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
   - echo "use=vendor/xp-framework/core" > xp.ini

--- a/src/main/php/webservices/rest/srv/ParamReader.class.php
+++ b/src/main/php/webservices/rest/srv/ParamReader.class.php
@@ -5,12 +5,10 @@ use webservices\rest\RestDeserializer;
 
 /**
  * Reads request parameters
- *
- * @test  xp://webservices.rest.unittest.srv.ParamReaderTest
  */
 abstract class ParamReader extends \lang\Enum {
   protected static $sources= array();
-  public static $COOKIE, $HEADER, $PARAM, $PATH, $BODY;
+  public static $COOKIE, $HEADER, $PARAM, $PATH, $BODY, $REQUEST;
 
   static function __static() {
     self::$sources['cookie']= self::$COOKIE= newinstance(__CLASS__, array(1, 'cookie'), '{
@@ -42,6 +40,12 @@ abstract class ParamReader extends \lang\Enum {
       static function __static() { }
       public function read($name, $target, $request) {
         return \webservices\rest\RestFormat::forMediaType($target["input"])->read($request->getInputStream(), \lang\Type::$VAR); 
+      }
+    }');
+    self::$sources['request']= self::$REQUEST= newinstance(__CLASS__, array(6, 'request'), '{
+      static function __static() { }
+      public function read($name, $target, $request) {
+        return $request;
       }
     }');
   }

--- a/src/main/php/webservices/rest/srv/ParamReader.class.php
+++ b/src/main/php/webservices/rest/srv/ParamReader.class.php
@@ -2,47 +2,50 @@
 
 use webservices\rest\RestFormat;
 use webservices\rest\RestDeserializer;
+use lang\IllegalArgumentException;
 
 /**
  * Reads request parameters
+ *
+ * @test  xp://webservices.rest.unittest.srv.ParamReaderTest
  */
 abstract class ParamReader extends \lang\Enum {
-  protected static $sources= array();
+  private static $sources= [];
   public static $COOKIE, $HEADER, $PARAM, $PATH, $BODY, $REQUEST;
 
   static function __static() {
-    self::$sources['cookie']= self::$COOKIE= newinstance(__CLASS__, array(1, 'cookie'), '{
+    self::$sources['cookie']= self::$COOKIE= newinstance(__CLASS__, [1, 'cookie'], '{
       static function __static() { }
       public function read($name, $target, $request) {
         if (null === ($cookie= $request->getCookie($name, null))) return null;
         return $cookie->getValue();
       }
     }');
-    self::$sources['header']= self::$HEADER= newinstance(__CLASS__, array(2, 'header'), '{
+    self::$sources['header']= self::$HEADER= newinstance(__CLASS__, [2, 'header'], '{
       static function __static() { }
       public function read($name, $target, $request) {
         return $request->getHeader($name, null);
       }
     }');
-    self::$sources['param']= self::$PARAM= newinstance(__CLASS__, array(3, 'param'), '{
+    self::$sources['param']= self::$PARAM= newinstance(__CLASS__, [3, 'param'], '{
       static function __static() { }
       public function read($name, $target, $request) {
         return $request->getParam($name, null);
       }
     }');
-    self::$sources['path']= self::$PATH= newinstance(__CLASS__, array(4, 'path'), '{
+    self::$sources['path']= self::$PATH= newinstance(__CLASS__, [4, 'path'], '{
       static function __static() { }
       public function read($name, $target, $request) {
         return isset($target["segments"][$name]) ? rawurldecode($target["segments"][$name]) : null;
       }
     }');
-    self::$sources['body']= self::$BODY= newinstance(__CLASS__, array(5, 'body'), '{
+    self::$sources['body']= self::$BODY= newinstance(__CLASS__, [5, 'body'], '{
       static function __static() { }
       public function read($name, $target, $request) {
         return \webservices\rest\RestFormat::forMediaType($target["input"])->read($request->getInputStream(), \lang\Type::$VAR); 
       }
     }');
-    self::$sources['request']= self::$REQUEST= newinstance(__CLASS__, array(6, 'request'), '{
+    self::$sources['request']= self::$REQUEST= newinstance(__CLASS__, [6, 'request'], '{
       static function __static() { }
       public function read($name, $target, $request) {
         return $request;
@@ -55,12 +58,13 @@ abstract class ParamReader extends \lang\Enum {
    *
    * @param  string name
    * @return self
+   * @throws lang.IllegalArgumentException
    */
   public static function forName($name) {
     if (isset(self::$sources[$name])) {
       return self::$sources[$name];
     }
-    throw new \lang\IllegalArgumentException('Invalid parameter source "'.$name.'"');
+    throw new IllegalArgumentException('Invalid parameter source "'.$name.'"');
   }
 
   /**

--- a/src/test/php/webservices/rest/unittest/srv/ParamReaderTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/ParamReaderTest.class.php
@@ -35,7 +35,7 @@ class ParamReaderTest extends \unittest\TestCase {
     return $r;
   }
 
-  #[@test, @values(['cookie', 'header', 'param', 'path', 'body'])]
+  #[@test, @values(['cookie', 'header', 'param', 'path', 'body', 'request'])]
   public function can_create($name) {
     ParamReader::forName($name);
   }
@@ -63,5 +63,11 @@ class ParamReaderTest extends \unittest\TestCase {
   #[@test]
   public function body() {
     $this->assertEquals('test', ParamReader::$BODY->read('name', ['input' => 'application/json'], $this->newRequest([], '"test"', [])));
+  }
+
+  #[@test]
+  public function request() {
+    $request= $this->newRequest([], '"test"', []);
+    $this->assertEquals($request, ParamReader::$REQUEST->read(null, [], $request));
   }
 }


### PR DESCRIPTION
This pull request introduces a `request` annotation which will pass a `scriptlet.Request` instance to the parameter. When type coercion occurs, a user type can receive this instance in its `valueOf()` method.

This is an enable for pagination, which may look like this in the future:

```php
#[@webservice]
class Administration extends Handler {
  const PAGE = 50;

  /**
   * Returns all URLs this URL shortener knows about
   *
   * @param  webservices.rest.srv.Pagination $pagination
   * @return webservices.rest.srv.Response
   */
  #[@webmethod(verb= 'GET', path= '/'), @$pagination: request]
  public function all(Pagination $pagination) {
    $links= $this->conn->select(
      'id, value from url limit %d, %d',
      $pagination->start(self::PAGE),
      self::PAGE
    );

    // TBI: "Link" header construction with rel=prev and rel=next
  }
}
```