### PR TITLE
Feature: Support valueOf() with multiple parameters 

### DIFF
--- a/src/main/php/webservices/rest/RestMarshalling.class.php
+++ b/src/main/php/webservices/rest/RestMarshalling.class.php
@@ -203,6 +203,10 @@ class RestMarshalling extends \lang\Object {
     } else if ($type->equals(XPClass::forName('util.Date'))) {
       return $type->newInstance($data);
     } else if ($type instanceof XPClass) {
+      if ($type->isInstance($data)) {
+        return $data;
+      }
+
       foreach ($this->marshallers->keys() as $t) {
         if ($t->isAssignableFrom($type)) return $this->marshallers[$t]->unmarshal($type, $data, $this);
       }

--- a/src/main/php/webservices/rest/srv/ParamReader.class.php
+++ b/src/main/php/webservices/rest/srv/ParamReader.class.php
@@ -78,7 +78,13 @@ abstract class ParamReader extends \lang\Enum {
    * @param   scriptlet.Request request
    */
   public function read($spec, $target, $request) {
-    if (is_array($spec)) {
+    if (isset($spec['use'])) {
+      if (isset($spec['names'])) {
+        return array_merge($this->read($spec['names'], $target, $request), $spec['use']);
+      } else {
+        return array_merge([$this->read(isset($spec['name']) ? $spec['name'] : null, $target, $request)], $spec['use']);
+      }
+    } else if (is_array($spec)) {
       $return= [];
       foreach ($spec as $name) {
         $return[$name]= $this->get($name, $target, $request);

--- a/src/main/php/webservices/rest/srv/ParamReader.class.php
+++ b/src/main/php/webservices/rest/srv/ParamReader.class.php
@@ -84,6 +84,14 @@ abstract class ParamReader extends \lang\Enum {
       } else {
         return array_merge([$this->read(isset($spec['name']) ? $spec['name'] : null, $target, $request)], $spec['use']);
       }
+    } else if (isset($spec['names'])) {
+      $return= [];
+      foreach ($spec['names'] as $name) {
+        $return[$name]= $this->get($name, $target, $request);
+      }
+      return $return;
+    } else if (isset($spec['name'])) {
+      return $this->get($spec['name'], $target, $request);
     } else if (is_array($spec)) {
       $return= [];
       foreach ($spec as $name) {

--- a/src/main/php/webservices/rest/srv/ParamReader.class.php
+++ b/src/main/php/webservices/rest/srv/ParamReader.class.php
@@ -2,6 +2,7 @@
 
 use webservices\rest\RestFormat;
 use webservices\rest\RestDeserializer;
+use lang\IllegalArgumentException;
 
 /**
  * Reads request parameters
@@ -9,38 +10,38 @@ use webservices\rest\RestDeserializer;
  * @test  xp://webservices.rest.unittest.srv.ParamReaderTest
  */
 abstract class ParamReader extends \lang\Enum {
-  protected static $sources= array();
+  private static $sources= [];
   public static $COOKIE, $HEADER, $PARAM, $PATH, $BODY;
 
   static function __static() {
-    self::$sources['cookie']= self::$COOKIE= newinstance(__CLASS__, array(1, 'cookie'), '{
+    self::$sources['cookie']= self::$COOKIE= newinstance(__CLASS__, [1, 'cookie'], '{
       static function __static() { }
-      public function read($name, $target, $request) {
+      protected function get($name, $target, $request) {
         if (null === ($cookie= $request->getCookie($name, null))) return null;
         return $cookie->getValue();
       }
     }');
-    self::$sources['header']= self::$HEADER= newinstance(__CLASS__, array(2, 'header'), '{
+    self::$sources['header']= self::$HEADER= newinstance(__CLASS__, [2, 'header'], '{
       static function __static() { }
-      public function read($name, $target, $request) {
+      protected function get($name, $target, $request) {
         return $request->getHeader($name, null);
       }
     }');
-    self::$sources['param']= self::$PARAM= newinstance(__CLASS__, array(3, 'param'), '{
+    self::$sources['param']= self::$PARAM= newinstance(__CLASS__, [3, 'param'], '{
       static function __static() { }
-      public function read($name, $target, $request) {
+      protected function get($name, $target, $request) {
         return $request->getParam($name, null);
       }
     }');
-    self::$sources['path']= self::$PATH= newinstance(__CLASS__, array(4, 'path'), '{
+    self::$sources['path']= self::$PATH= newinstance(__CLASS__, [4, 'path'], '{
       static function __static() { }
-      public function read($name, $target, $request) {
+      protected function get($name, $target, $request) {
         return isset($target["segments"][$name]) ? rawurldecode($target["segments"][$name]) : null;
       }
     }');
-    self::$sources['body']= self::$BODY= newinstance(__CLASS__, array(5, 'body'), '{
+    self::$sources['body']= self::$BODY= newinstance(__CLASS__, [5, 'body'], '{
       static function __static() { }
-      public function read($name, $target, $request) {
+      protected function get($name, $target, $request) {
         return \webservices\rest\RestFormat::forMediaType($target["input"])->read($request->getInputStream(), \lang\Type::$VAR); 
       }
     }');
@@ -51,20 +52,40 @@ abstract class ParamReader extends \lang\Enum {
    *
    * @param  string name
    * @return self
+   * @throws lang.IllegalArgumentException
    */
   public static function forName($name) {
     if (isset(self::$sources[$name])) {
       return self::$sources[$name];
     }
-    throw new \lang\IllegalArgumentException('Invalid parameter source "'.$name.'"');
+    throw new IllegalArgumentException('Invalid parameter source "'.$name.'"');
   }
 
   /**
-   * Read this parameter from the given request
+   * Get a single parameter from the given request
    *
    * @param   string name
    * @param   [:var] target Routing target
    * @param   scriptlet.Request request
    */
-  public abstract function read($name, $target, $request);
+  protected abstract function get($name, $target, $request);
+
+  /**
+   * Read this parameter from the given request
+   *
+   * @param   var spec
+   * @param   [:var] target Routing target
+   * @param   scriptlet.Request request
+   */
+  public function read($spec, $target, $request) {
+    if (is_array($spec)) {
+      $return= [];
+      foreach ($spec as $name) {
+        $return[$name]= $this->get($name, $target, $request);
+      }
+      return $return;
+    } else {
+      return $this->get($spec, $target, $request);
+    }
+  }
 }

--- a/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
@@ -11,7 +11,6 @@ use util\TimeZone;
 use util\Money;
 use util\Currency;
 use webservices\rest\RestMarshalling;
-use unittest\actions\RuntimeVersion;
 
 /**
  * TestCase

--- a/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
@@ -11,6 +11,7 @@ use util\TimeZone;
 use util\Money;
 use util\Currency;
 use webservices\rest\RestMarshalling;
+use unittest\actions\RuntimeVersion;
 
 /**
  * TestCase
@@ -451,56 +452,90 @@ class RestMarshallingTest extends \unittest\TestCase {
 
   #[@test]
   public function unmarshal_no_constructor() {
-    $class= ClassLoader::defineClass('RestConversionTest_NoConstructor', 'webservices.rest.unittest.ConstructorFixture', [], '{
-    }');
-    $c= $class->newInstance();
-    $c->id= 4711;
-    $this->assertEquals(
-      $c,
-      $this->fixture->unmarshal($class, ['id' => 4711])
-    );
+    $class= ClassLoader::defineClass('RestConversionTest_NoConstructor', 'webservices.rest.unittest.ConstructorFixture', [], '{}');
+    $this->assertEquals(4711, $this->fixture->unmarshal($class, ['id' => 4711])->id);
   }
 
-  #[@test]
-  public function unmarshal_static_valueof_method() {
-    $class= ClassLoader::defineClass('RestConversionTest_StaticValueOf', 'webservices.rest.unittest.ConstructorFixture', [], '{
-      protected function __construct($id) { $this->id= (int)$id; }
+  #[@test, @values([
+  #  [4711],
+  #  [[4711]],
+  #  [[4711, 0815]],
+  #  [['id' => 4711]],
+  #  [['id' => 4711, 'name' => 'Test']]
+  #])]
+  public function unmarshal_static_valueof_method($input) {
+    $class= ClassLoader::defineClass('RestConversionTest_StaticValueOf', 'lang.Object', [], '{
+      public $passed;
+      public static function valueOf($args) { $self= new self(); $self->passed= $args; return $self; }
+    }');
+    $this->assertEquals($input, $this->fixture->unmarshal($class, $input)->passed);
+  }
+
+  #[@test, @values([
+  #  [4711],
+  #  [[4711]],
+  #  [[4711, 0815]],
+  #  [['id' => 4711]],
+  #  [['id' => 4711, 'name' => 'Test']]
+  #])]
+  public function unmarshal_static_valueof_method_with_array_param($input) {
+    $class= ClassLoader::defineClass('RestConversionTest_StaticValueOfWithArrayParam', 'lang.Object', [], '{
+      public $passed;
+      public static function valueOf(array $args) { $self= new self(); $self->passed= $args; return $self; }
+    }');
+    $this->assertEquals((array)$input, $this->fixture->unmarshal($class, $input)->passed);
+  }
+
+  #[@test, @values([
+  #  [4711],
+  #  [[4711]],
+  #  [[4711, 0815]],
+  #  [['id' => 4711]],
+  #  [['id' => 4711, 'name' => 'Test']]
+  #])]
+  public function unmarshal_static_valueof_method_with_int_param($input) {
+    $class= ClassLoader::defineClass('RestConversionTest_StaticValueOfWithIntParam', 'webservices.rest.unittest.ConstructorFixture', [], '{
+      protected function __construct($id) { $this->id= $id; }
+      /** @param int $id */
       public static function valueOf($id) { return new self($id); }
     }');
-    $this->assertEquals(
-      $class->getMethod('valueOf')->invoke(null, [4711]),
-      $this->fixture->unmarshal($class, ['id' => 4711])
-    );
+    $this->assertEquals(4711, $this->fixture->unmarshal($class, $input)->id);
+  }
+
+  #[@test, @values([
+  #  [[4711, 'Test']],
+  #  [['id' => 4711, 'name' => 'Test']]
+  #])]
+  public function unmarshal_static_valueof_method_with_multiple_params($input) {
+    $class= ClassLoader::defineClass('RestConversionTest_StaticValueOfWithMultipleParams', 'lang.Object', [], '{
+      public $passed;
+      public static function valueOf($id, $name) { $self= new self(); $self->passed= [$id, $name]; return $self; }
+    }');
+    $this->assertEquals([4711, 'Test'], $this->fixture->unmarshal($class, $input)->passed);
   }
 
   #[@test]
   public function unmarshal_public_valueof_instance_method_not_invoked() {
     $class= ClassLoader::defineClass('RestConversionTest_PublicValueOf', 'webservices.rest.unittest.ConstructorFixture', [], '{
-      public function valueOf($id) { throw new IllegalStateException("Should not reach this point!"); }
+      public function valueOf($id) { throw new \lang\IllegalStateException("Should not reach this point!"); }
     }');
-    $c= $class->newInstance();
-    $c->id= 4711;
-    $this->assertEquals($c, $this->fixture->unmarshal($class, ['id' => 4711]));
+    $this->assertEquals(4711, $this->fixture->unmarshal($class, ['id' => 4711])->id);
   }
 
   #[@test]
   public function unmarshal_private_valueof_instance_method_not_invoked() {
     $class= ClassLoader::defineClass('RestConversionTest_PrivateValueOf', 'webservices.rest.unittest.ConstructorFixture', [], '{
-      private static function valueOf($id) { throw new IllegalStateException("Should not reach this point!"); }
+      private static function valueOf($id) { throw new \lang\IllegalStateException("Should not reach this point!"); }
     }');
-    $c= $class->newInstance();
-    $c->id= 4711;
-    $this->assertEquals($c, $this->fixture->unmarshal($class, ['id' => 4711]));
+    $this->assertEquals(4711, $this->fixture->unmarshal($class, ['id' => 4711])->id);
   }
 
   #[@test]
   public function unmarshal_protected_valueof_instance_method_not_invoked() {
     $class= ClassLoader::defineClass('RestConversionTest_ProtectedValueOf', 'webservices.rest.unittest.ConstructorFixture', [], '{
-      protected static function valueOf($id) { throw new IllegalStateException("Should not reach this point!"); }
+      protected static function valueOf($id) { throw new \lang\IllegalStateException("Should not reach this point!"); }
     }');
-    $c= $class->newInstance();
-    $c->id= 4711;
-    $this->assertEquals($c, $this->fixture->unmarshal($class, ['id' => 4711]));
+    $this->assertEquals(4711, $this->fixture->unmarshal($class, ['id' => 4711])->id);
   }
 
   #[@test]
@@ -516,25 +551,7 @@ class RestMarshallingTest extends \unittest\TestCase {
     $class= ClassLoader::defineClass('RestConversionTest_ConstructorVsSetter', 'webservices.rest.unittest.ConstructorFixture', [], '{
       public $name;
       public function __construct() { 
-        if (func_num_args() > 0) throw new IllegalStateException("Should not reach this point!");
-      }
-      public function withId($id) { $this->id= $id; return $this; }
-      public function withName($name) { $this->name= $name; return $this; }
-      public function equals($cmp) { return parent::equals($cmp) && $this->name === $cmp->name; }
-      public function toString() { return parent::toString()."(name=\'".$this->name."\')"; }
-    }');
-    $this->assertEquals(
-      $class->newInstance()->withId(4711)->withName('Test'),
-      $this->fixture->unmarshal($class, ['id' => 4711, 'name' => 'Test'])
-    );
-  }
-
-  #[@test]
-  public function unmarshal_valueof_not_used_with_complex_payload() {
-    $class= ClassLoader::defineClass('RestConversionTest_ValueOfVsSetter', 'webservices.rest.unittest.ConstructorFixture', [], '{
-      public $name;
-      public static function valueOf($id) { 
-        throw new IllegalStateException("Should not reach this point!");
+        if (func_num_args() > 0) throw new \lang\IllegalStateException("Should not reach this point!");
       }
       public function withId($id) { $this->id= $id; return $this; }
       public function withName($name) { $this->name= $name; return $this; }

--- a/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
@@ -450,6 +450,12 @@ class RestMarshallingTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function unmarshal_already_instance_of() {
+    $issue= new IssueWithField(1, 'test1');
+    $this->assertEquals($issue, $this->fixture->unmarshal($issue->getClass(), $issue));
+  }
+
+  #[@test]
   public function unmarshal_no_constructor() {
     $class= ClassLoader::defineClass('RestConversionTest_NoConstructor', 'webservices.rest.unittest.ConstructorFixture', [], '{}');
     $this->assertEquals(4711, $this->fixture->unmarshal($class, ['id' => 4711])->id);

--- a/src/test/php/webservices/rest/unittest/srv/ParamReaderTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/ParamReaderTest.class.php
@@ -75,4 +75,28 @@ class ParamReaderTest extends \unittest\TestCase {
   public function body() {
     $this->assertEquals('test', ParamReader::$BODY->read('name', ['input' => 'application/json'], $this->newRequest([], '"test"', [])));
   }
+
+  #[@test]
+  public function use_with_empty() {
+    $this->assertEquals(
+      [null, 'Test'],
+      ParamReader::$PARAM->read(['use' => ['Test']], [], $this->newRequest([], '', []))
+    );
+  }
+
+  #[@test]
+  public function use_with_name() {
+    $this->assertEquals(
+      ['test', 'Test'],
+      ParamReader::$PARAM->read(['name' => 't', 'use' => ['Test']], [], $this->newRequest(['t' => 'test'], '', []))
+    );
+  }
+
+  #[@test]
+  public function use_with_names() {
+    $this->assertEquals(
+      ['t1' => 'a', 't2' => 'b', 'c'],
+      ParamReader::$PARAM->read(['names' => ['t1', 't2'], 'use' => ['c']], [], $this->newRequest(['t1' => 'a', 't2' => 'b'], '', []))
+    );
+  }
 }

--- a/src/test/php/webservices/rest/unittest/srv/ParamReaderTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/ParamReaderTest.class.php
@@ -55,6 +55,11 @@ class ParamReaderTest extends \unittest\TestCase {
     $this->assertEquals('test', ParamReader::$PARAM->read('name', [], $this->newRequest(['name' => 'test'], '', [])));
   }
 
+  #[@test]
+  public function param_via_name() {
+    $this->assertEquals('test', ParamReader::$PARAM->read(['name' => 't'], [], $this->newRequest(['t' => 'test'], '', [])));
+  }
+
   #[@test, @values([
   #  [['color' => 'green', 'price' => '$12.99']],
   #  [['price' => '$12.99', 'color' => 'green']]
@@ -63,6 +68,17 @@ class ParamReaderTest extends \unittest\TestCase {
     $this->assertEquals(
       ['color' => 'green', 'price' => '$12.99'],
       ParamReader::$PARAM->read(['color', 'price'], [], $this->newRequest($input, '', []))
+    );
+  }
+
+  #[@test, @values([
+  #  [['color' => 'green', 'price' => '$12.99']],
+  #  [['price' => '$12.99', 'color' => 'green']]
+  #])]
+  public function params_via_names($input) {
+    $this->assertEquals(
+      ['color' => 'green', 'price' => '$12.99'],
+      ParamReader::$PARAM->read(['names' => ['color', 'price']], [], $this->newRequest($input, '', []))
     );
   }
 

--- a/src/test/php/webservices/rest/unittest/srv/ParamReaderTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/ParamReaderTest.class.php
@@ -55,6 +55,17 @@ class ParamReaderTest extends \unittest\TestCase {
     $this->assertEquals('test', ParamReader::$PARAM->read('name', [], $this->newRequest(['name' => 'test'], '', [])));
   }
 
+  #[@test, @values([
+  #  [['color' => 'green', 'price' => '$12.99']],
+  #  [['price' => '$12.99', 'color' => 'green']]
+  #])]
+  public function params($input) {
+    $this->assertEquals(
+      ['color' => 'green', 'price' => '$12.99'],
+      ParamReader::$PARAM->read(['color', 'price'], [], $this->newRequest($input, '', []))
+    );
+  }
+
   #[@test]
   public function path() {
     $this->assertEquals('test', ParamReader::$PATH->read('name', ['segments' => ['name' => 'test']], $this->newRequest([], '', [])));


### PR DESCRIPTION
This pull request adds support for `valueOf()` methods with multiple parameters by passing all elements of an iterable structure as arguments if the method declares more than one parameter. Combined with support for selecting multiple values from parameters, headers, cookies and path segments, we can handle more complex scenarios.

## One-arg valueOf
If we have a static valueOf() method accepting a single argument, the value read from the respective source will be coerced to the parameter type and passed in. This was the previous behavior and has not changed.

```php
class Money extends \lang\Object {

  /**
   * Creates a money value from a given string input
   *
   * @param  string $input
   * @return self
   */
  public static function valueOf($input) {
    // TBI
  }
}
```

If the class declares a valueOf() method with multiple parameters, the value from the respective source will be iterated and the iteration's results will be passed as arguments. See below for an example.

## Selecting one or more values
The following also works with headers, cookies and path segments via their respective annotations `header`, `cookie` and `path`.

```php
[@$val: param]                         // Select parameter "val" - inferred from variable name
[@$val: param('name')]                 // Select parameter named "name"
[@$val: param(['value', 'currency'])]  // Select parameters "value" and "currency"
[@$val: param(name= 'test')]           // Select parameter named "test"
[@$val: param(names= ['a', 'b'])]      // Select parameters "a" and "b"
```

## Passing more values
The new "use" annotation key can be used to merge the input values.

```php
[@$pager: request(use= ['start', 'count'])]   // Pass request + the strings "start" and "account".
```

This can feed the following valueOf() declaration:

```php
class Pagination extends \lang\Object {

  /**
   * Creates a pagination instance
   *
   * @param  scriptlet.Request $request
   * @param  string $pageParam
   * @param  string $limitParam
   * @return self
   */
  public static function valueOf($request, $pageParam, $limitParam) {
    // TBI
  }
}
```