### PR TITLE
Add RestResponse::error()

### DIFF
--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -171,7 +171,7 @@ class RestResponse extends \lang\Object {
     $this->handleStatus($this->response->statusCode());
  
     if (null === $type) {
-      $target= \lang\Type::$VAR;
+      $target= $this->type ?: \lang\Type::$VAR;  // BC
     } else if ($type instanceof \lang\Type) {
       $target= $type;
     } else {
@@ -196,7 +196,7 @@ class RestResponse extends \lang\Object {
     $this->handleError($this->response->statusCode());
  
     if (null === $type) {
-      $target= $this->type ?: \lang\Type::$VAR;  // BC
+      $target= \lang\Type::$VAR;
     } else if ($type instanceof \lang\Type) {
       $target= $type;
     } else {

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -49,6 +49,15 @@ class RestResponse extends \lang\Object {
   }
 
   /**
+   * Get whether this response is an error (>= 400)
+   *
+   * @return  bool
+   */
+  public function isError() {
+    return $this->response->statusCode() >= 400;
+  }
+
+  /**
    * Get data
    *
    * @return  string

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -4,7 +4,6 @@ use io\streams\Streams;
 use io\streams\MemoryInputStream;
 use peer\http\HttpResponse;
 
-
 /**
  * A REST response
  *
@@ -131,7 +130,21 @@ class RestResponse extends \lang\Object {
    */
   protected function handleStatus($code) {
     if ($code > 399) {
-      throw new RestException($code.': '.$this->response->message());
+      throw new RestException('Expected success but have '.$code.' '.$this->response->message());
+    }
+  }
+
+  /**
+   * Handle error code. Throws an exception in this default implementation
+   * if the numeric value is less than 400. Overwrite in subclasses to 
+   * change this behaviour.
+   *
+   * @param   int code
+   * @throws  webservices.rest.RestException
+   */
+  protected function handleError($code) {
+    if ($code < 400) {
+      throw new RestException('Expected an error but have '.$code.' '.$this->response->message());
     }
   }
 
@@ -156,6 +169,31 @@ class RestResponse extends \lang\Object {
    */
   public function data($type= null) {
     $this->handleStatus($this->response->statusCode());
+ 
+    if (null === $type) {
+      $target= \lang\Type::$VAR;
+    } else if ($type instanceof \lang\Type) {
+      $target= $type;
+    } else {
+      $target= \lang\Type::forName($type);
+    }
+
+    if (null === $this->reader) {
+      throw new \lang\IllegalArgumentException('Unknown content type "'.$this->headers['Content-Type'][0].'"');
+    }
+
+    return $this->handlePayloadOf($target);
+  }
+
+  /**
+   * Get error
+   *
+   * @param   var type target type of deserialization, either a lang.Type or a string
+   * @return  var
+   * @throws  webservices.rest.RestException if the status code is > 399
+   */
+  public function error($type= null) {
+    $this->handleError($this->response->statusCode());
  
     if (null === $type) {
       $target= $this->type ?: \lang\Type::$VAR;  // BC

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -144,20 +144,6 @@ class RestResponse extends \lang\Object {
   }
 
   /**
-   * Handle error code. Throws an exception in this default implementation
-   * if the numeric value is less than 400. Overwrite in subclasses to 
-   * change this behaviour.
-   *
-   * @param   int code
-   * @throws  webservices.rest.RestException
-   */
-  protected function handleError($code) {
-    if ($code < 400) {
-      throw new RestException('Expected an error but have '.$code.' '.$this->response->message());
-    }
-  }
-
-  /**
    * Handle payload deserialization. Uses the deserializer passed to the
    * constructor to deserialize the input stream and coerces it to the 
    * passed target type. Overwrite in subclasses to change this behaviour.
@@ -202,7 +188,9 @@ class RestResponse extends \lang\Object {
    * @throws  webservices.rest.RestException if the status code is > 399
    */
   public function error($type= null) {
-    $this->handleError($this->response->statusCode());
+    if (!$this->isError()) {
+      throw new RestException('Expected an error but have '.$this->response->statusCode().' '.$this->response->message());
+    }
  
     if (null === $type) {
       $target= \lang\Type::$VAR;

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -9,6 +9,7 @@ use webservices\rest\RestJsonDeserializer;
 use webservices\rest\RestResponse;
 use webservices\rest\ResponseReader;
 use webservices\rest\RestMarshalling;
+use webservices\rest\RestException;
 use lang\ClassNotFoundException;
 use lang\Type;
 use lang\XPClass;
@@ -37,12 +38,14 @@ class RestResponseTest extends TestCase {
    * @param   string $content
    * @param   string $headers
    * @param   string $body
+   * @param   string $status Status code and message
    * @return  webservices.rest.RestResponse
    */
-  protected function newFixture($content, $headers, $body) {
+  protected function newFixture($content, $headers, $body, $status= '200 OK') {
     return new RestResponse(
       new HttpResponse(new MemoryInputStream(sprintf(
-        "HTTP/1.1 200 OK\r\nContent-Type: %s\r\nContent-Length: %d%s\r\n\r\n%s",
+        "HTTP/1.1 %s\r\nContent-Type: %s\r\nContent-Length: %d%s\r\n\r\n%s",
+        $status,
         $content,
         strlen($body),
         $headers ? "\r\n".implode("\r\n", $headers) : '',
@@ -101,6 +104,32 @@ class RestResponseTest extends TestCase {
       ['one' => '1', 'two' => '2; httpOnly'],
       $this->newFixture(self::JSON, $headers, '')->cookies()
     );
+  }
+
+  #[@test]
+  public function data() {
+    $this->assertEquals(
+      [],
+      $this->newFixture(self::JSON, [], '[]', '200 OK')->data()
+    );
+  }
+
+  #[@test, @expect(class= RestException::class, withMessage= 'Expected success but have 404 Not Found')]
+  public function data_raises_exception_with_error_status() {
+    $this->newFixture(self::JSON, [], '{"message" : "No user ~test"}', '404 Not Found')->data();
+  }
+
+  #[@test]
+  public function error() {
+    $this->assertEquals(
+      ['message' => 'No user ~test'],
+      $this->newFixture(self::JSON, [], '{"message" : "No user ~test"}', '404 Not Found')->error()
+    );
+  }
+
+  #[@test, @expect(class= RestException::class, withMessage= 'Expected an error but have 200 OK')]
+  public function error_raises_exception_with_success_status() {
+    $this->newFixture(self::JSON, [], '[]', '200 OK')->error();
   }
 
   #[@test]

--- a/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestResponseTest.class.php
@@ -106,6 +106,17 @@ class RestResponseTest extends TestCase {
     );
   }
 
+  #[@test, @values([
+  #  ['200 OK', false],
+  #  ['300 Multiple Choices', false],
+  #  ['399 (undefined)', false],
+  #  ['400 Bad Request', true],
+  #  ['500 Internal Server Error', true]
+  #])]
+  public function isError($status, $result) {
+    $this->assertEquals($result, $this->newFixture(self::JSON, [], '[]', $status)->isError());
+  }
+
   #[@test]
   public function data() {
     $this->assertEquals(


### PR DESCRIPTION
This method complements the data() method, which will return a value only if the HTTP response status is < 399, and raise an exception otherwise. This is to prevent programming mistakes, and to force users to explicitely handle errors!

### Example
```php
use com\example\rest\Orders;

// Will throw if server yields an error code, e.g. 503 Service Unavailable
$orders= $client->execute(new RestRequest(...))->data(Orders::class);
```

### Example of error-aware handling
```php
use com\example\rest\ErrorMessage;
use com\example\rest\Orders;

$response= $client->execute(new RestRequest(...));
if ($response->isError()) {
  throw $response->error(ErrorMessage::class);
}

$orders= $response->data(Orders::class);
```

### Availability
This will bump the version number to **7.1.0**