### PR TITLE
Use xp-forge/json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,13 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^7.0 | ^6.5",
-    "xp-framework/webservices": "^7.0 | ^6.3",
     "xp-framework/http": "^7.0 | ^6.2",
     "xp-framework/xml": "^7.0 | ^6.0",
-    "xp-framework/scriptlet": "^8.0 | ^6.2",
+    "xp-framework/scriptlet": "^8.0.1 | ^6.2",
     "xp-framework/logging": "^7.0 | ^6.5",
     "xp-framework/collections": "^7.0 | ^6.5",
     "xp-framework/networking": "^7.0 | ^6.6",
+    "xp-forge/json": "^2.1",
     "php" : ">=5.5.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "xp-framework/logging": "^7.0 | ^6.5",
     "xp-framework/collections": "^7.0 | ^6.5",
     "xp-framework/networking": "^7.0 | ^6.6",
-    "xp-forge/json": "^2.1",
+    "xp-forge/json": "^2.0",
     "php" : ">=5.5.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "xp-framework/collections": "^7.0 | ^6.5",
     "xp-framework/networking": "^7.0 | ^6.6",
     "xp-framework/tokenize": "^7.0 | ^6.5",
-    "xp-forge/json": "^2.0",
+    "xp-forge/json": "^2.1",
     "php" : ">=5.5.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "xp-framework/core": "^7.0 | ^6.5",
     "xp-framework/http": "^7.0 | ^6.2",
     "xp-framework/xml": "^7.0 | ^6.0",
-    "xp-framework/scriptlet": "^8.0.1 | ^6.2",
+    "xp-framework/scriptlet": "^8.0.1",
     "xp-framework/logging": "^7.0 | ^6.5",
     "xp-framework/collections": "^7.0 | ^6.5",
     "xp-framework/networking": "^7.0 | ^6.6",

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "xp-framework/logging": "^7.0 | ^6.5",
     "xp-framework/collections": "^7.0 | ^6.5",
     "xp-framework/networking": "^7.0 | ^6.6",
+    "xp-framework/tokenize": "^7.0 | ^6.5",
     "xp-forge/json": "^2.0",
     "php" : ">=5.5.0"
   },

--- a/src/main/php/webservices/rest/RestJsonDeserializer.class.php
+++ b/src/main/php/webservices/rest/RestJsonDeserializer.class.php
@@ -1,7 +1,6 @@
 <?php namespace webservices\rest;
 
-use webservices\json\JsonFactory;
-
+use text\json\StreamInput;
 
 /**
  * A JSON deserializer
@@ -10,14 +9,6 @@ use webservices\json\JsonFactory;
  * @test  xp://net.xp_framework.unittest.webservices.rest.RestJsonDeserializerTest
  */
 class RestJsonDeserializer extends RestDeserializer {
-  protected $json;
-
-  /**
-   * Constructor. Initializes decoder member
-   */
-  public function __construct() {
-    $this->json= JsonFactory::create();
-  }
 
   /**
    * Deserialize
@@ -27,10 +18,6 @@ class RestJsonDeserializer extends RestDeserializer {
    * @throws  lang.FormatException
    */
   public function deserialize($in) {
-    try {
-      return $this->json->decodeFrom($in);
-    } catch (\webservices\json\JsonException $e) {
-      throw new \lang\FormatException('Malformed JSON', $e);
-    }
+    return (new StreamInput($in))->read();
   }
 }

--- a/src/main/php/webservices/rest/RestJsonSerializer.class.php
+++ b/src/main/php/webservices/rest/RestJsonSerializer.class.php
@@ -13,10 +13,12 @@ class RestJsonSerializer extends RestSerializer {
   private $format;
 
   /**
-   * Constructor. Initializes decoder member
+   * Constructor.
+   *
+   * @param  text.json.Format $format Optional wire format, defaults to *dense* format
    */
-  public function __construct() {
-    $this->format= WireFormat::dense();
+  public function __construct(WireFormat $format= null) {
+    $this->format= $format ?: WireFormat::dense();
   }
 
   /**

--- a/src/main/php/webservices/rest/RestJsonSerializer.class.php
+++ b/src/main/php/webservices/rest/RestJsonSerializer.class.php
@@ -24,7 +24,7 @@ class RestJsonSerializer extends RestSerializer {
   /**
    * Return the Content-Type header's value
    *
-   * @return  string
+   * @return string
    */
   public function contentType() {
     return 'application/json; charset=utf-8';
@@ -33,38 +33,14 @@ class RestJsonSerializer extends RestSerializer {
   /**
    * Serialize
    *
-   * @param   var $payload
-   * @param   io.streams.OutputStream $out
-   * @return  void
+   * @param  var $payload
+   * @param  io.streams.OutputStream $out
+   * @return void
    */
   public function serialize($payload, $out) {
-    $val= $payload instanceof Payload ? $payload->value : $payload;
-    $json= new StreamOutput($out, $this->format);
-    if ($val instanceof \Traversable) {
-      $i= 0;
-      $map= null;
-      foreach ($val as $key => $element) {
-        if (0 === $i++) {
-          $map= 0 !== $key;
-          $json->appendToken($map ? '{' : '[');
-        } else {
-          $json->appendToken(',');
-        }
-
-        if ($map) {
-          $json->write($key);
-          $json->appendToken(':');
-        }
-        $json->write($element);
-      }
-      if (null === $map) {
-        $json->appendToken('[]');
-      } else {
-        $out->write($map ? '}' : ']');
-      }
-    } else {
-      $json->write($val);
-    }
-    $json->close();
+    (new StreamOutput($out, $this->format))->write($payload instanceof Payload
+      ? $payload->value
+      : $payload
+    );
   }
 }

--- a/src/test/php/webservices/rest/unittest/RestFormatTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestFormatTest.class.php
@@ -19,12 +19,12 @@ class RestFormatTest extends TestCase {
   public function json_serialize() {
     $res= new MemoryOutputStream();
     RestFormat::$JSON->write($res, new Payload(['name' => 'Timm']));
-    $this->assertEquals('{ "name" : "Timm" }', $res->getBytes());
+    $this->assertEquals('{"name":"Timm"}', $res->getBytes());
   }
 
   #[@test]
   public function json_deserialize() {
-    $req= new MemoryInputStream('{ "name" : "Timm" }');
+    $req= new MemoryInputStream('{"name":"Timm"}');
     $v= RestFormat::$JSON->read($req, MapType::forName('[:string]'));
     $this->assertEquals(['name' => 'Timm'], $v); 
   }

--- a/src/test/php/webservices/rest/unittest/RestJsonSerializerTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestJsonSerializerTest.class.php
@@ -35,14 +35,14 @@ class RestJsonSerializerTest extends TestCase {
     $this->assertEquals('"'.$str.'"', $this->serialize($str));
   }
 
-  #[@test, @values([-1, 0, 1, 4711])]
-  public function integers($int) {
-    $this->assertEquals(''.$int, $this->serialize($int));
+  #[@test, @values([['-1', -1], ['0', 0], ['1', 1], ['4711', 4711]])]
+  public function integers($expected, $int) {
+    $this->assertEquals($expected, $this->serialize($int));
   }
 
-  #[@test, @values([-1.0, 0.0, 1.0, 47.11])]
-  public function decimals($decimal) {
-    $this->assertEquals(''.$decimal, $this->serialize($decimal));
+  #[@test, @values([['-1.0', -1.0], ['0.0', 0.0], ['1.0', 1.0], ['47.11', 47.11]])]
+  public function decimals($expected, $decimal) {
+    $this->assertEquals($expected, $this->serialize($decimal));
   }
 
   #[@test]
@@ -57,23 +57,23 @@ class RestJsonSerializerTest extends TestCase {
 
   #[@test]
   public function empty_array() {
-    $this->assertEquals('[ ]', $this->serialize([]));
+    $this->assertEquals('[]', $this->serialize([]));
   }
 
   #[@test]
   public function int_array() {
-    $this->assertEquals('[ 1 , 2 , 3 ]', $this->serialize([1, 2, 3]));
+    $this->assertEquals('[1,2,3]', $this->serialize([1, 2, 3]));
   }
 
   #[@test]
   public function string_array() {
-    $this->assertEquals('[ "a" , "b" , "c" ]', $this->serialize(['a', 'b', 'c']));
+    $this->assertEquals('["a","b","c"]', $this->serialize(['a', 'b', 'c']));
   }
 
   #[@test]
   public function string_map() {
     $this->assertEquals(
-      '{ "a" : "One" , "b" : "Two" , "c" : "Three" }',
+      '{"a":"One","b":"Two","c":"Three"}',
       $this->serialize(['a' => 'One', 'b' => 'Two', 'c' => 'Three'])
     );
   }
@@ -84,7 +84,7 @@ class RestJsonSerializerTest extends TestCase {
   #])]
   public function traversable_array($in) {
     $this->assertEquals(
-      '[ 1 , 2 , 3 ]',
+      '[1,2,3]',
       $this->serialize($in)
     );
   }
@@ -95,7 +95,7 @@ class RestJsonSerializerTest extends TestCase {
   #])]
   public function traversable_map($in) {
     $this->assertEquals(
-      '{ "color" : "green" , "price" : "$12.99" }',
+      '{"color":"green","price":"$12.99"}',
       $this->serialize($in)
     );
   }
@@ -106,7 +106,7 @@ class RestJsonSerializerTest extends TestCase {
   #])]
   public function empty_traversable($in) {
     $this->assertEquals(
-      '[ ]',
+      '[]',
       $this->serialize($in)
     );
   }

--- a/src/test/php/webservices/rest/unittest/srv/RestContextTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/RestContextTest.class.php
@@ -409,7 +409,7 @@ class RestContextTest extends TestCase {
       'output'   => 'text/json'
     ];
     $this->assertProcess(
-      400, ['Content-Type: text/json'], '{ "message" : "Parameter \"name\" required, but not found in path(\'name\')" }',
+      400, ['Content-Type: text/json'], '{"message":"Parameter \"name\" required, but not found in path(\'name\')"}',
       $route, $this->newRequest()
     );
   }
@@ -557,7 +557,7 @@ class RestContextTest extends TestCase {
     ];
 
     $this->assertProcess(
-      500, ['Content-Type: text/json'], '{ "message" : "Cannot instantiate" }',
+      500, ['Content-Type: text/json'], '{"message":"Cannot instantiate"}',
       $route, $this->newRequest()
     );
   }
@@ -574,7 +574,7 @@ class RestContextTest extends TestCase {
     ];
 
     $this->assertProcess(
-      500, ['Content-Type: text/json'], '{ "message" : "Cannot instantiate" }',
+      500, ['Content-Type: text/json'], '{"message":"Cannot instantiate"}',
       $route, $this->newRequest()
     );
   }
@@ -591,7 +591,7 @@ class RestContextTest extends TestCase {
     ];
 
     $this->assertProcess(
-      500, ['Content-Type: text/json'], '{ "message" : "Invocation failed" }',
+      500, ['Content-Type: text/json'], '{"message":"Invocation failed"}',
       $route, $this->newRequest()
     );
   }
@@ -608,7 +608,7 @@ class RestContextTest extends TestCase {
     ];
 
     $this->assertProcess(
-      409, ['Content-Type: text/json'], '{ "message" : "Invocation failed" }',
+      409, ['Content-Type: text/json'], '{"message":"Invocation failed"}',
       $route, $this->newRequest()
     );
   }

--- a/src/test/php/webservices/rest/unittest/srv/RestScriptletTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/RestScriptletTest.class.php
@@ -61,9 +61,13 @@ class RestScriptletTest extends TestCase {
     $res= new HttpScriptletResponse();
     $fixture->doProcess($req, $res);
 
+    $res->sendContent();
+    $sent= ob_get_contents();
+    ob_end_clean();
+
     $this->assertEquals(404, $res->statusCode);
     $this->assertEquals('Content-Type: application/json', $res->headers[0]);
-    $this->assertEquals('{ "message" : "Could not route request to http:\/\/localhost\/" }', $res->getContent());
+    $this->assertEquals('{"message":"Could not route request to http://localhost/"}', $sent);
   }
 
   #[@test, @values([

--- a/src/test/php/webservices/rest/unittest/srv/RestScriptletTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/RestScriptletTest.class.php
@@ -61,6 +61,7 @@ class RestScriptletTest extends TestCase {
     $res= new HttpScriptletResponse();
     $fixture->doProcess($req, $res);
 
+    ob_start();
     $res->sendContent();
     $sent= ob_get_contents();
     ob_end_clean();


### PR DESCRIPTION
## Performance
Using slightly less memory, we get a 7-fold permance increase.

Dimension | Before | After |
| ----------- | ----------- | --------- |
| Runtime | 10.833 seconds | 1.481 seconds |
| Iteration | 108.3 ms per iteration, result = 30 | 14.8 ms per iteration, result = 30 |
| Memory | 1176.195 kB memory used | 1055.477 kB memory used |
| Peak memory | 1573.680 kB peak | 1101.750 kB peak |

*Parsing a 150 kB JSON file*

## Fixes

* The JSON library handles surrogate pairs correctly - see https://github.com/xp-forge/json/pull/6
* The JSON library also handles nested [traversables](http://php.net/traversable) correctly

## Possible BC break

We need a fix in the scriptlet library and cannot have compat with ^6.2, ^7.0 and 8.0 but require [the 8.0.1 bugfix release](https://github.com/xp-framework/scriptlet/releases/tag/v8.0.1) to work correctly. The scriptlet library does not introduce any problematic changes for 7.0 and 8.0 but rather chose to announce major features with these versions, so it might not be relevant in the real word!

## JSON output changes

The output format is now more dense by default - there are no superfluous spaces or newlines in the JSON output. Also, slashes are no longer escaped (e.g. `http:\/\/example.com\/`). Tests relying on this exact behavior will need to be changed.

## Versioning

Given the changes above - most probably won't break any real-life situation but could cause trouble if people have relied on the whitespace in JSON I suggest to release this as a major version (8.0.0) so people stop, think, and maybe read this before upgrading /cc @lluchs @kiesel 