### PR TITLE
CRUD shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,30 @@ Here's an overview of the typical usage for working with the REST API.
 
 ```php
 use webservices\rest\RestClient;
+
+$client= new RestClient('http://api.example.com/');
+
+// Create 
+$response= $client->post('/users', ['name' => 'Test'], 'application/json');
+if (201 === $response->status()) {
+  $url= $response->header('Location');
+}
+
+// Read as map or unmarshal to object
+$map= $client->get('/users/self')->data();
+$object= $client->get('/users/self')->data(User::class);
+
+// Pass parameters
+$list= $client->get('/users', ['page' => 1])->data();
+
+// Pass segments
+$client->delete(['/user/{id}', 'id' => 6100]);
+```
+
+If you need to customize the request beyong the typical uses, use the `execute()` method.
+
+```php
+use webservices\rest\RestClient;
 use webservices\rest\RestRequest;
 use peer\http\HttpConstants;
 

--- a/README.md
+++ b/README.md
@@ -22,18 +22,22 @@ Here's an overview of the typical usage for working with the REST API.
 
 ```php
 use webservices\rest\RestClient;
+use com\example\User;
 
 $client= new RestClient('http://api.example.com/');
 
 // Create 
 $response= $client->post('/users', ['name' => 'Test'], 'application/json');
-if (201 === $response->status()) {
-  $url= $response->header('Location');
+if (201 !== $response->status()) {
+  throw new IllegalStateException('Could not create user!');
 }
+$url= $response->header('Location');
 
-// Read as map or unmarshal to object
-$map= $client->get('/users/self')->data();
-$object= $client->get('/users/self')->data(User::class);
+// Update, returns data as map. Will throw an exception for return codes >= 400
+$user= $client->put($url, ['name' => 'Tested'], 'application/json')->data();
+
+// Unmarshal to object by passing a type
+$user= $client->get('/users/self')->data(User::class);
 
 // Pass parameters
 $list= $client->get('/users', ['page' => 1])->data();

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $list= $client->get('users', ['page' => 1, 'per_page' => 50])->data();
 $client= (new RestClient('http://api.example.com/'))
   ->using(RestFormat::$JSON)
   ->accepting(RestFormat::$JSON)
+  ->with('User-Agent', 'Test')
 ;
 
 // Default content type and accept types set on connection used

--- a/README.md
+++ b/README.md
@@ -16,31 +16,52 @@ Client
 
 The `RestClient` class serves as the entry point to this API. Create a new instance of it with the REST service's endpoint URL and then invoke its `execute()` method to work with the resources.
 
-### Example
-
-Here's an overview of the typical usage for working with the REST API.
+### Creating: post
 
 ```php
-use webservices\rest\RestClient;
-use com\example\User;
-
 $client= new RestClient('http://api.example.com/');
-
-// Create 
 $response= $client->post('users', ['name' => 'Test'], 'application/json');
+
+// Check status codes
 if (201 !== $response->status()) {
   throw new IllegalStateException('Could not create user!');
 }
+
+// Retrieve response headers
 $url= $response->header('Location');
+```
 
-// Update, returns data as map. Will throw an exception for return codes >= 400
-$user= $client->put($url, ['name' => 'Tested'], 'application/json')->data();
+### Reading: get / head
+```php
+$client= new RestClient('http://api.example.com/');
 
-// Unmarshal to object by passing a type
+// Unmarshal to object by optionally passing a type; otherwise returned as map
 $user= $client->get('users/self')->data(User::class);
 
+// Test for existance with HEAD
+$exists= (200 === $client->head('users/1549')->status());
+
 // Pass parameters
-$list= $client->get('users', ['page' => 1])->data();
+$list= $client->get('users', ['page' => 1, 'per_page' => 50])->data();
+```
+
+### Updating: put / patch
+```php
+$client= (new RestClient('http://api.example.com/'))
+  ->using(RestFormat::$JSON)
+  ->accepting(RestFormat::$JSON)
+;
+
+// Default content type and accept types set on connection used
+$updated= $client->put('users/self', ['name' => 'Tested', 'login' => $mail])->data();
+
+// Can also use PATCH - typically used to modify only parts of the resoure
+$updated= $client->patch('users/self', ['name' => 'Changed'])->data();
+```
+
+### Deleting: delete
+```php
+$client= new RestClient('http://api.example.com/');
 
 // Pass segments
 $client->delete(['user/{id}', 'id' => 6100]);

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ use com\example\User;
 $client= new RestClient('http://api.example.com/');
 
 // Create 
-$response= $client->post('/users', ['name' => 'Test'], 'application/json');
+$response= $client->post('users', ['name' => 'Test'], 'application/json');
 if (201 !== $response->status()) {
   throw new IllegalStateException('Could not create user!');
 }
@@ -37,13 +37,13 @@ $url= $response->header('Location');
 $user= $client->put($url, ['name' => 'Tested'], 'application/json')->data();
 
 // Unmarshal to object by passing a type
-$user= $client->get('/users/self')->data(User::class);
+$user= $client->get('users/self')->data(User::class);
 
 // Pass parameters
-$list= $client->get('/users', ['page' => 1])->data();
+$list= $client->get('users', ['page' => 1])->data();
 
 // Pass segments
-$client->delete(['/user/{id}', 'id' => 6100]);
+$client->delete(['user/{id}', 'id' => 6100]);
 ```
 
 If you need to customize the request beyong the typical uses, use the `execute()` method.
@@ -51,12 +51,11 @@ If you need to customize the request beyong the typical uses, use the `execute()
 ```php
 use webservices\rest\RestClient;
 use webservices\rest\RestRequest;
-use peer\http\HttpConstants;
 
 $client= new RestClient('http://api.example.com/');
 
-$request= (new RestRequest('/resource/{id}'))
- ->withMethod(HttpConstants::GET)
+$request= (new RestRequest('resource/{id}'))
+ ->withMethod('GET')
  ->withSegment('id', 5000)
  ->withParameter('details', 'true')
  ->withHeader('X-Binford', '6100 (more power)'

--- a/src/main/php/webservices/rest/RestClient.class.php
+++ b/src/main/php/webservices/rest/RestClient.class.php
@@ -241,6 +241,8 @@ class RestClient extends \lang\Object implements Traceable {
     $key= $url->getHost();
     if (!isset($this->connections[$key])) {
       $this->connections[$key]= $this->connectionTo->__invoke($url);
+      $this->connections[$key]->setConnectTimeout($this->connectTimeout);
+      $this->connections[$key]->setTimeout($this->readTimeout);
     }
 
     $send= $this->connections[$key]->create(new HttpRequest());

--- a/src/main/php/webservices/rest/RestClient.class.php
+++ b/src/main/php/webservices/rest/RestClient.class.php
@@ -268,6 +268,39 @@ class RestClient extends \lang\Object implements Traceable {
   }
 
   /**
+   * Executes a PATCH request against a given resource
+   *
+   * @param  string|array $resource
+   * @param  var $payload Payload to be serialized
+   * @param  string $type The content-type
+   * @return webservices.rest.RestResponse
+   */
+  public function patch($resource, $payload, $type= null) {
+    $request= $this->newRequest($resource, HttpConstants::PATCH);
+    $request->setPayload($payload, $type ?: $this->format);
+    return $this->execute($request);
+  }
+
+  /**
+   * Executes a HEAD request against a given resource
+   *
+   * @param  string|array $resource
+   * @param  [:string] $params
+   * @param  string[] $accept The accept-types
+   * @return webservices.rest.RestResponse
+   */
+  public function head($resource, $params= [], $accept= []) {
+    $request= $this->newRequest($resource, HttpConstants::HEAD);
+    foreach ($params as $name => $param) {
+      $request->addParameter($name, $param);
+    }
+    foreach ((array)$accept ?: $this->accept as $range) {
+      $request->addAccept($range);
+    }
+    return $this->execute($request);
+  }
+
+  /**
    * Execute a request
    *
    * @param  webservices.rest.RestRequest $request

--- a/src/main/php/webservices/rest/RestClient.class.php
+++ b/src/main/php/webservices/rest/RestClient.class.php
@@ -239,9 +239,7 @@ class RestClient extends \lang\Object implements Traceable {
   public function execute(RestRequest $request) {
     $url= $request->targetUrl($this->base);
     $key= $url->getHost();
-    if (isset($this->connections[$key])) {
-      $this->connections[$key];
-    } else {
+    if (!isset($this->connections[$key])) {
       $this->connections[$key]= $this->connectionTo->__invoke($url);
     }
 

--- a/src/main/php/webservices/rest/RestClient.class.php
+++ b/src/main/php/webservices/rest/RestClient.class.php
@@ -243,11 +243,15 @@ class RestClient extends \lang\Object implements Traceable {
    * @param  string|array $resource
    * @param  var $payload Payload to be serialized
    * @param  string $type The content-type
+   * @param  string|string[] $accept The accept-types
    * @return webservices.rest.RestResponse
    */
-  public function post($resource, $payload, $type= null) {
+  public function post($resource, $payload, $type= null, $accept= []) {
     $request= $this->newRequest($resource, HttpConstants::POST);
     $request->setPayload($payload, $type ?: $this->contentType);
+    foreach ((array)$accept as $range) {
+      $request->addAccept($range);
+    }
     return $this->execute($request);
   }
 
@@ -257,11 +261,15 @@ class RestClient extends \lang\Object implements Traceable {
    * @param  string|array $resource
    * @param  var $payload Payload to be serialized
    * @param  string $type The content-type
+   * @param  string|string[] $accept The accept-types
    * @return webservices.rest.RestResponse
    */
-  public function put($resource, $payload, $type= null) {
+  public function put($resource, $payload, $type= null, $accept= []) {
     $request= $this->newRequest($resource, HttpConstants::PUT);
     $request->setPayload($payload, $type ?: $this->contentType);
+    foreach ((array)$accept as $range) {
+      $request->addAccept($range);
+    }
     return $this->execute($request);
   }
 
@@ -286,11 +294,15 @@ class RestClient extends \lang\Object implements Traceable {
    * @param  string|array $resource
    * @param  var $payload Payload to be serialized
    * @param  string $type The content-type
+   * @param  string|string[] $accept The accept-types
    * @return webservices.rest.RestResponse
    */
-  public function patch($resource, $payload, $type= null) {
+  public function patch($resource, $payload, $type= null, $accept= []) {
     $request= $this->newRequest($resource, HttpConstants::PATCH);
     $request->setPayload($payload, $type ?: $this->contentType);
+    foreach ((array)$accept as $range) {
+      $request->addAccept($range);
+    }
     return $this->execute($request);
   }
 

--- a/src/main/php/webservices/rest/RestClient.class.php
+++ b/src/main/php/webservices/rest/RestClient.class.php
@@ -21,6 +21,7 @@ class RestClient extends \lang\Object implements Traceable {
   private $base= null;
   private $cat= null;
   private $accept= [];
+  private $headers= [];
   private $format= null;
   private $serializers= [];
   private $deserializers= [];
@@ -68,6 +69,18 @@ class RestClient extends \lang\Object implements Traceable {
     } else {
       $this->format= $format;
     }
+    return $this;
+  }
+
+  /**
+   * Adds a header to be sent with every request
+   *
+   * @param  string $header
+   * @param  var $value
+   * @return self
+   */
+  public function with($header, $value= null) {
+    $this->headers[$header]= $value;
     return $this;
   }
 
@@ -316,6 +329,7 @@ class RestClient extends \lang\Object implements Traceable {
     }
 
     $send= $this->connections[$key]->create(new HttpRequest());
+    $send->addHeaders($this->headers);
     $send->addHeaders($request->headerList());
     $send->setMethod($request->getMethod());
     $send->setTarget($url->getPath());

--- a/src/main/php/webservices/rest/RestClient.class.php
+++ b/src/main/php/webservices/rest/RestClient.class.php
@@ -3,6 +3,7 @@
 use util\log\Traceable;
 use peer\http\HttpConnection;
 use peer\http\HttpRequest;
+use peer\http\HttpConstants;
 use lang\IllegalStateException;
 use lang\IllegalArgumentException;
 use lang\XPClass;
@@ -182,6 +183,83 @@ class RestClient extends \lang\Object implements Traceable {
     } else {
       return RestFormat::forMediaType($mediaType)->serializer();
     }
+  }
+
+  /**
+   * Creates a new request object
+   *
+   * @param  string|array $resource
+   * @param  string $method
+   * @return webservices.rest.RestRequest
+   */
+  private function newRequest($resource, $method) {
+    if (is_array($resource)) {
+      $request= new RestRequest(array_shift($resource), $method);
+      foreach ($resource as $segment => $name) {
+        $request->addSegment($segment, $name);
+      }
+    } else {
+      $request= new RestRequest($resource, $method);
+    }
+    return $request;
+  }
+
+  /**
+   * Executes a GET request against a given resource
+   *
+   * @param  string|array $resource
+   * @param  [:string] $params
+   * @return webservices.rest.RestResponse
+   */
+  public function get($resource, $params= []) {
+    $request= $this->newRequest($resource, HttpConstants::GET);
+    foreach ($params as $name => $param) {
+      $request->addParameter($name, $param);
+    }
+    return $this->execute($request);
+  }
+
+  /**
+   * Executes a POST request against a given resource
+   *
+   * @param  string|array $resource
+   * @param  var $payload Payload to be serialized
+   * @param  string $type The content-type
+   * @return webservices.rest.RestResponse
+   */
+  public function post($resource, $payload, $type) {
+    $request= $this->newRequest($resource, HttpConstants::POST);
+    $request->setPayload($payload, $type);
+    return $this->execute($request);
+  }
+
+  /**
+   * Executes a PUT request against a given resource
+   *
+   * @param  string|array $resource
+   * @param  var $payload Payload to be serialized
+   * @param  string $type The content-type
+   * @return webservices.rest.RestResponse
+   */
+  public function put($resource, $payload, $type) {
+    $request= $this->newRequest($resource, HttpConstants::PUT);
+    $request->setPayload($payload, $type);
+    return $this->execute($request);
+  }
+
+  /**
+   * Executes a DELETE request against a given resource
+   *
+   * @param  string|array $resource
+   * @param  [:string] $params
+   * @return webservices.rest.RestResponse
+   */
+  public function delete($resource, $params= []) {
+    $request= $this->newRequest($resource, HttpConstants::DELETE);
+    foreach ($params as $name => $param) {
+      $request->addParameter($name, $param);
+    }
+    return $this->execute($request);
   }
 
   /**

--- a/src/main/php/webservices/rest/RestRequest.class.php
+++ b/src/main/php/webservices/rest/RestRequest.class.php
@@ -395,6 +395,20 @@ class RestRequest extends \lang\Object {
     );
   }
 
+  /** @return php.Traversable */
+  public function placeHolders() {
+    $l= strlen($this->resource);
+    $offset= 0;
+    do {
+      $b= strcspn($this->resource, '{', $offset);
+      $offset+= $b;
+      if ($offset >= $l) break;
+      $e= strcspn($this->resource, '}', $offset);
+      yield substr($this->resource, $offset+ 1, $e- 1);
+      $offset+= $e+ 1;
+    } while ($offset < $l);
+  }
+
   /**
    * Gets query
    *

--- a/src/main/php/webservices/rest/RestRequest.class.php
+++ b/src/main/php/webservices/rest/RestRequest.class.php
@@ -398,6 +398,21 @@ class RestRequest extends \lang\Object {
   }
 
   /**
+   * Copy authentication if on same host 
+   *
+   * @param  peer.URL $base
+   * @param  peer.URL $url
+   * @return peer.URL The given URL
+   */
+  private function authorize($base, $url) {
+    if ($base && ($url->getHost() === $base->getHost())) {
+      $url->setUser($base->getUser());
+      $url->setPassword($base->getPassword());
+    }
+    return $url;
+  }
+
+  /**
    * Resolves target URL
    *
    * @param  peer.URL $base
@@ -406,16 +421,12 @@ class RestRequest extends \lang\Object {
    */
   public function targetUrl(URL $base= null) {
     if (strpos($this->resource, '://')) {
-      $url= new URL($this->resource);
-      if ($base && ($url->getHost() === $base->getHost())) {
-        $url->setUser($base->getUser());
-        $url->setPassword($base->getPassword());
-      }
+      $url= $this->authorize($base, new URL($this->resource));
       $resource= $url->getPath();
     } else if (null === $base) {
       throw new IllegalStateException('No base set');
     } else if (0 === strncmp('//',  $this->resource, 2)) {
-      $url= new URL($base->getScheme().':'.$this->resource);
+      $url= $this->authorize($base, new URL($base->getScheme().':'.$this->resource));
       $resource= $url->getPath();
     } else if ('/' === $this->resource{0}) {
       $resource= $this->resource;

--- a/src/main/php/webservices/rest/RestRequest.class.php
+++ b/src/main/php/webservices/rest/RestRequest.class.php
@@ -136,6 +136,15 @@ class RestRequest extends \lang\Object {
   }
 
   /**
+   * Gets accepted mime types
+   *
+   * @return  string[]
+   */
+  public function getAccept() {
+    return $this->accept;
+  }
+
+  /**
    * Adds a cookie
    *
    * @param   string $name cookie name
@@ -385,16 +394,12 @@ class RestRequest extends \lang\Object {
   }
 
   /**
-   * Returns all headers
+   * Returns headers except Content-Type and Accept
    *
    * @return  peer.http.Header[]
    */
   public function headerList() {
-    return array_merge(
-      $this->headers,
-      $this->contentType ? [new Header('Content-Type', $this->contentType)] : [],
-      $this->accept ? [new Header('Accept', implode(', ', $this->accept))] : []
-    );
+    return $this->headers;
   }
 
   /**

--- a/src/main/php/webservices/rest/RestRequest.class.php
+++ b/src/main/php/webservices/rest/RestRequest.class.php
@@ -414,6 +414,12 @@ class RestRequest extends \lang\Object {
       $resource= $url->getPath();
     } else if (null === $base) {
       throw new IllegalStateException('No base set');
+    } else if (0 === strncmp('//',  $this->resource, 2)) {
+      $url= new URL($base->getScheme().':'.$this->resource);
+      $resource= $url->getPath();
+    } else if ('/' === $this->resource{0}) {
+      $resource= $this->resource;
+      $url= clone $base;
     } else {
       $resource= rtrim($base->getPath('/'), '/').'/'.ltrim($this->resource, '/');
       $url= clone $base;

--- a/src/main/php/webservices/rest/RestRequest.class.php
+++ b/src/main/php/webservices/rest/RestRequest.class.php
@@ -453,30 +453,6 @@ class RestRequest extends \lang\Object {
   }
 
   /**
-   * Gets query
-   *
-   * @param   string base
-   * @return  string query
-   */
-  public function getTarget($base= '/') {
-    $resource= rtrim($base, '/').'/'.ltrim($this->resource, '/');
-    $l= strlen($resource);
-    $target= '';
-    $offset= 0;
-    do {
-      $b= strcspn($resource, '{', $offset);
-      $target.= substr($resource, $offset, $b);
-      $offset+= $b;
-      if ($offset >= $l) break;
-      $e= strcspn($resource, '}', $offset);
-      $target.= urlencode($this->getSegment(substr($resource, $offset+ 1, $e- 1)));
-      $offset+= $e+ 1;
-    } while ($offset < $l);
-    return $target;
-  }
-
-
-  /**
    * Creates a string representation
    *
    * @return string

--- a/src/test/php/webservices/rest/unittest/RestClientExecutionTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientExecutionTest.class.php
@@ -21,8 +21,8 @@ class RestClientExecutionTest extends TestCase {
   #[@beforeClass]
   public static function dummyConnectionClass() {
     self::$conn= ClassLoader::defineClass('RestClientExecutionTest_Connection', 'peer.http.HttpConnection', [], '{
-      protected $result= NULL;
-      protected $exception= NULL;
+      protected $result= null;
+      protected $exception= null;
 
       public function __construct($status, $body, $headers) {
         parent::__construct("http://test");
@@ -56,8 +56,10 @@ class RestClientExecutionTest extends TestCase {
    * @return  webservices.rest.RestClient
    */
   public function fixtureWith($status, $body= null, $headers= []) {
-    $fixture= new RestClient();
-    $fixture->setConnection(self::$conn->newInstance($status, $body, $headers));
+    $fixture= new RestClient('http://test');
+    $fixture->usingConnections(function($url) use($status, $body, $headers) {
+      return self::$conn->newInstance($status, $body, $headers);
+    });
     return $fixture;
   }
 

--- a/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
@@ -285,4 +285,41 @@ class RestClientSendTest extends TestCase {
       $this->fixture->delete('/user', ['name' => 'test'])->content()
     );
   }
+
+  #[@test]
+  public function patch() {
+    $this->assertEquals(
+      "PATCH /user HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Content-Type: application/json\r\n".
+      "Content-Length: 15\r\n".
+      "\r\n".
+      "{\"name\":\"Test\"}",
+      $this->fixture->patch('/user', ['name' => 'Test'], 'application/json')->content()
+    );
+  }
+
+  #[@test]
+  public function head() {
+    $this->assertEquals(
+      "HEAD /user/1 HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "\r\n",
+      $this->fixture->head('/user/1')->content()
+    );
+  }
+
+  #[@test]
+  public function head_with_accept() {
+    $this->assertEquals(
+      "HEAD / HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Accept: */*\r\n".
+      "\r\n",
+      $this->fixture->head('/', [], '*/*')->content()
+    );
+  }
 }

--- a/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
@@ -28,16 +28,16 @@ class RestClientSendTest extends TestCase {
 
   #[@beforeClass]
   public static function requestEchoingConnectionClass() {
-    self::$conn= ClassLoader::defineClass('RestClientSendTest_Connection', HttpConnection::class, [], [
-      'send' => function(HttpRequest $request) {
+    self::$conn= ClassLoader::defineClass('RestClientSendTest_Connection', HttpConnection::class, [], '{
+      public function send(\peer\http\HttpRequest $request) {
         $str= $request->getRequestString();
-        return new HttpResponse(new MemoryInputStream(sprintf(
+        return new \peer\http\HttpResponse(new \io\streams\MemoryInputStream(sprintf(
           "HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s",
           strlen($str),
           $str
         )));
       }
-    ]);
+    }');
   }
 
   #[@test]

--- a/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
@@ -24,7 +24,7 @@ class RestClientSendTest extends TestCase {
   #[@beforeClass]
   public static function requestEchoingConnectionClass() {
     self::$conn= ClassLoader::defineClass('RestClientSendTest_Connection', 'peer.http.HttpConnection', [], '{
-      public function __construct() {
+      public function __construct($url) {
         parent::__construct("http://test");
       }
       
@@ -43,8 +43,7 @@ class RestClientSendTest extends TestCase {
    * Creates fixture.
    */
   public function setUp() {
-    $this->fixture= new RestClient();
-    $this->fixture->setConnection(self::$conn->newInstance());
+    $this->fixture= (new RestClient('http://user:pass@test'))->usingConnections([self::$conn, 'newInstance']);
   }
 
   #[@test]
@@ -134,6 +133,17 @@ class RestClientSendTest extends TestCase {
       "Host: test\r\n".
       "\r\n",
       $this->fixture->get('/users', ['page' => 1])->content()
+    );
+  }
+
+  #[@test]
+  public function get_with_full_url() {
+    $this->assertEquals(
+      "GET /users?page=1 HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "\r\n",
+      $this->fixture->get('http://test/users', ['page' => 1])->content()
     );
   }
 

--- a/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
@@ -111,6 +111,43 @@ class RestClientSendTest extends TestCase {
   }
 
   #[@test]
+  public function get_with_accept() {
+    $this->assertEquals(
+      "GET / HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Accept: */*\r\n".
+      "\r\n",
+      $this->fixture->get('/', [], '*/*')->content()
+    );
+  }
+
+  #[@test]
+  public function get_with_multiple_accept_headers() {
+    $this->assertEquals(
+      "GET / HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Accept: application/json, text/xml;q=0.5\r\n".
+      "\r\n",
+      $this->fixture->get('/', [], ['application/json', 'text/xml;q=0.5'])->content()
+    );
+  }
+
+
+  #[@test]
+  public function get_uses_accept() {
+    $this->assertEquals(
+      "GET / HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Accept: */*\r\n".
+      "\r\n",
+      $this->fixture->accepting('*/*')->get('/')->content()
+    );
+  }
+
+  #[@test]
   public function get_with_segment() {
     $this->assertEquals(
       "GET /user/6100 HTTP/1.1\r\n".
@@ -161,6 +198,20 @@ class RestClientSendTest extends TestCase {
   }
 
   #[@test]
+  public function post_uses_default_format() {
+    $this->assertEquals(
+      "POST /user HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Content-Type: application/json; charset=utf-8\r\n".
+      "Content-Length: 15\r\n".
+      "\r\n".
+      "{\"name\":\"Test\"}",
+      $this->fixture->using(RestFormat::$JSON)->post('/user', ['name' => 'Test'])->content()
+    );
+  }
+
+  #[@test]
   public function put() {
     $this->assertEquals(
       "PUT /user/self HTTP/1.1\r\n".
@@ -185,6 +236,20 @@ class RestClientSendTest extends TestCase {
       "\r\n".
       "{\"name\":\"Test\"}",
       $this->fixture->put(['/user/{id}', 'id' => 0], ['name' => 'Test'], 'application/json')->content()
+    );
+  }
+
+  #[@test]
+  public function put_uses_default_format() {
+    $this->assertEquals(
+      "PUT /user HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Content-Type: application/json; charset=utf-8\r\n".
+      "Content-Length: 15\r\n".
+      "\r\n".
+      "{\"name\":\"Test\"}",
+      $this->fixture->using(RestFormat::$JSON)->put('/user', ['name' => 'Test'])->content()
     );
   }
 

--- a/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
@@ -103,4 +103,126 @@ class RestClientSendTest extends TestCase {
       $this->fixture->execute((new RestRequest('/', HttpConstants::POST))->withPayload(['key' => 'value'], RestFormat::$FORM))->content()
     );
   }
+
+  #[@test]
+  public function get() {
+    $this->assertEquals(
+      "GET / HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "\r\n",
+      $this->fixture->get('/')->content()
+    );
+  }
+
+  #[@test]
+  public function get_with_segment() {
+    $this->assertEquals(
+      "GET /user/6100 HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "\r\n",
+      $this->fixture->get(['/user/{id}', 'id' => 6100])->content()
+    );
+  }
+
+  #[@test]
+  public function get_with_parameter() {
+    $this->assertEquals(
+      "GET /users?page=1 HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "\r\n",
+      $this->fixture->get('/users', ['page' => 1])->content()
+    );
+  }
+
+  #[@test]
+  public function post() {
+    $this->assertEquals(
+      "POST /user HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Content-Type: application/json\r\n".
+      "Content-Length: 15\r\n".
+      "\r\n".
+      "{\"name\":\"Test\"}",
+      $this->fixture->post('/user', ['name' => 'Test'], 'application/json')->content()
+    );
+  }
+
+  #[@test]
+  public function post_with_segment() {
+    $this->assertEquals(
+      "POST /user/6100/emails HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Content-Type: application/json\r\n".
+      "Content-Length: 30\r\n".
+      "\r\n".
+      "{\"address\":\"test@example.com\"}",
+      $this->fixture->post(['/user/{id}/emails', 'id' => 6100], ['address' => 'test@example.com'], 'application/json')->content()
+    );
+  }
+
+  #[@test]
+  public function put() {
+    $this->assertEquals(
+      "PUT /user/self HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Content-Type: application/json\r\n".
+      "Content-Length: 15\r\n".
+      "\r\n".
+      "{\"name\":\"Test\"}",
+      $this->fixture->put('/user/self', ['name' => 'Test'], 'application/json')->content()
+    );
+  }
+
+  #[@test]
+  public function put_with_segment() {
+    $this->assertEquals(
+      "PUT /user/0 HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Content-Type: application/json\r\n".
+      "Content-Length: 15\r\n".
+      "\r\n".
+      "{\"name\":\"Test\"}",
+      $this->fixture->put(['/user/{id}', 'id' => 0], ['name' => 'Test'], 'application/json')->content()
+    );
+  }
+
+  #[@test]
+  public function delete() {
+    $this->assertEquals(
+      "DELETE /user/1 HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "\r\n",
+      $this->fixture->delete('/user/1')->content()
+    );
+  }
+
+  #[@test]
+  public function delete_with_segment() {
+    $this->assertEquals(
+      "DELETE /user/1 HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "\r\n",
+      $this->fixture->delete(['/user/{id}', 'id' => 1])->content()
+    );
+  }
+
+  #[@test]
+  public function delete_with_parameter() {
+    $this->assertEquals(
+      "DELETE /user?name=test HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "\r\n",
+      $this->fixture->delete('/user', ['name' => 'test'])->content()
+    );
+  }
 }

--- a/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
@@ -18,12 +18,14 @@ use lang\ClassLoader;
  * @see   xp://webservices.rest.RestClient
  */
 class RestClientSendTest extends TestCase {
-  protected static $conn= null;   
-  protected $fixture= null;
+  private static $conn;
+  private $fixture;
 
-  /**
-   * Creates connection class which echoes the request
-   */
+  /** @return void */
+  public function setUp() {
+    $this->fixture= (new RestClient('http://test/api'))->usingConnections([self::$conn, 'newInstance']);
+  }
+
   #[@beforeClass]
   public static function requestEchoingConnectionClass() {
     self::$conn= ClassLoader::defineClass('RestClientSendTest_Connection', HttpConnection::class, [], [
@@ -36,13 +38,6 @@ class RestClientSendTest extends TestCase {
         )));
       }
     ]);
-  }
-
-  /**
-   * Creates fixture.
-   */
-  public function setUp() {
-    $this->fixture= (new RestClient('http://test/api'))->usingConnections([self::$conn, 'newInstance']);
   }
 
   #[@test]

--- a/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
@@ -48,8 +48,8 @@ class RestClientSendTest extends TestCase {
       "POST / HTTP/1.1\r\n".
       "Connection: close\r\n".
       "Host: test\r\n".
-      "Content-Length: 5\r\n".
       "Content-Type: application/x-www-form-urlencoded\r\n".
+      "Content-Length: 5\r\n".
       "\r\n".
       "Hello",
       $this->fixture->execute((new RestRequest('/', HttpConstants::POST))->withBody(new RequestData('Hello')))->content()
@@ -96,6 +96,19 @@ class RestClientSendTest extends TestCase {
       "\r\n".
       "key=value",
       $this->fixture->execute((new RestRequest('/', HttpConstants::POST))->withPayload(['key' => 'value'], RestFormat::$FORM))->content()
+    );
+  }
+
+  #[@test]
+  public function default_accept() {
+    $fixture= $this->fixture->accepting('application/json');
+    $this->assertEquals(
+      "GET / HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "Accept: application/json\r\n".
+      "\r\n",
+      $fixture->execute(new RestRequest('/', HttpConstants::GET))->content()
     );
   }
 

--- a/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
@@ -170,6 +170,18 @@ class RestClientSendTest extends TestCase {
   }
 
   #[@test]
+  public function with_header() {
+    $this->assertEquals(
+      "GET / HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "User-Agent: Test\r\n".
+      "\r\n",
+      $this->fixture->with('User-Agent', 'Test')->get('/')->content()
+    );
+  }
+
+  #[@test]
   public function post() {
     $this->assertEquals(
       "POST /user HTTP/1.1\r\n".

--- a/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
@@ -24,10 +24,6 @@ class RestClientSendTest extends TestCase {
   #[@beforeClass]
   public static function requestEchoingConnectionClass() {
     self::$conn= ClassLoader::defineClass('RestClientSendTest_Connection', 'peer.http.HttpConnection', [], '{
-      public function __construct($url) {
-        parent::__construct("http://test");
-      }
-      
       public function send(\peer\http\HttpRequest $request) {
         $str= $request->getRequestString();
         return new \peer\http\HttpResponse(new \io\streams\MemoryInputStream(sprintf(
@@ -43,7 +39,7 @@ class RestClientSendTest extends TestCase {
    * Creates fixture.
    */
   public function setUp() {
-    $this->fixture= (new RestClient('http://user:pass@test'))->usingConnections([self::$conn, 'newInstance']);
+    $this->fixture= (new RestClient('http://test/api'))->usingConnections([self::$conn, 'newInstance']);
   }
 
   #[@test]
@@ -144,6 +140,39 @@ class RestClientSendTest extends TestCase {
       "Host: test\r\n".
       "\r\n",
       $this->fixture->get('http://test/users', ['page' => 1])->content()
+    );
+  }
+
+  #[@test]
+  public function get_with_slashslash_url() {
+    $this->assertEquals(
+      "GET /users?page=1 HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: example\r\n".
+      "\r\n",
+      $this->fixture->get('//example/users', ['page' => 1])->content()
+    );
+  }
+
+  #[@test]
+  public function get_with_relative_url() {
+    $this->assertEquals(
+      "GET /api/user HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "\r\n",
+      $this->fixture->get('user')->content()
+    );
+  }
+
+  #[@test]
+  public function get_with_dotdot_url() {
+    $this->assertEquals(
+      "GET /api/../user HTTP/1.1\r\n".
+      "Connection: close\r\n".
+      "Host: test\r\n".
+      "\r\n",
+      $this->fixture->get('../user')->content()
     );
   }
 

--- a/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
@@ -6,6 +6,9 @@ use webservices\rest\RestRequest;
 use webservices\rest\RestFormat;
 use io\streams\MemoryInputStream;
 use peer\http\HttpConstants;
+use peer\http\HttpConnection;
+use peer\http\HttpRequest;
+use peer\http\HttpResponse;
 use peer\http\RequestData;
 use lang\ClassLoader;
 
@@ -23,16 +26,16 @@ class RestClientSendTest extends TestCase {
    */
   #[@beforeClass]
   public static function requestEchoingConnectionClass() {
-    self::$conn= ClassLoader::defineClass('RestClientSendTest_Connection', 'peer.http.HttpConnection', [], '{
-      public function send(\peer\http\HttpRequest $request) {
+    self::$conn= ClassLoader::defineClass('RestClientSendTest_Connection', HttpConnection::class, [], [
+      'send' => function(HttpRequest $request) {
         $str= $request->getRequestString();
-        return new \peer\http\HttpResponse(new \io\streams\MemoryInputStream(sprintf(
+        return new HttpResponse(new MemoryInputStream(sprintf(
           "HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s",
           strlen($str),
           $str
         )));
       }
-    }');
+    ]);
   }
 
   /**

--- a/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientSendTest.class.php
@@ -133,50 +133,6 @@ class RestClientSendTest extends TestCase {
   }
 
   #[@test]
-  public function get_with_full_url() {
-    $this->assertEquals(
-      "GET /users?page=1 HTTP/1.1\r\n".
-      "Connection: close\r\n".
-      "Host: test\r\n".
-      "\r\n",
-      $this->fixture->get('http://test/users', ['page' => 1])->content()
-    );
-  }
-
-  #[@test]
-  public function get_with_slashslash_url() {
-    $this->assertEquals(
-      "GET /users?page=1 HTTP/1.1\r\n".
-      "Connection: close\r\n".
-      "Host: example\r\n".
-      "\r\n",
-      $this->fixture->get('//example/users', ['page' => 1])->content()
-    );
-  }
-
-  #[@test]
-  public function get_with_relative_url() {
-    $this->assertEquals(
-      "GET /api/user HTTP/1.1\r\n".
-      "Connection: close\r\n".
-      "Host: test\r\n".
-      "\r\n",
-      $this->fixture->get('user')->content()
-    );
-  }
-
-  #[@test]
-  public function get_with_dotdot_url() {
-    $this->assertEquals(
-      "GET /api/../user HTTP/1.1\r\n".
-      "Connection: close\r\n".
-      "Host: test\r\n".
-      "\r\n",
-      $this->fixture->get('../user')->content()
-    );
-  }
-
-  #[@test]
   public function post() {
     $this->assertEquals(
       "POST /user HTTP/1.1\r\n".

--- a/src/test/php/webservices/rest/unittest/RestClientTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestClientTest.class.php
@@ -81,7 +81,7 @@ class RestClientTest extends TestCase {
     $this->newFixture()->execute(null);
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= 'No connection set')]
+  #[@test, @expect(class= IllegalStateException::class, withMessage= 'No base set')]
   public function executeWithoutBase() {
     $this->newFixture()->execute(new \webservices\rest\RestRequest());
   }
@@ -195,7 +195,7 @@ class RestClientTest extends TestCase {
   #[@test]
   public function stringRepresentation() {
     $this->assertEquals(
-      "webservices.rest.RestClient(->null)",
+      "webservices.rest.RestClient(->(null), timeout: [read= 60.00, connect= 2.00])",
       $this->newFixture()->toString()
     );
   }
@@ -203,7 +203,7 @@ class RestClientTest extends TestCase {
   #[@test]
   public function stringRepresentationWithBase() {
     $this->assertEquals(
-      "webservices.rest.RestClient(->peer.http.HttpConnection(->URL{http://api.example.com/ via peer.http.SocketHttpTransport}, timeout: [read= 60.00, connect= 2.00]))",
+      "webservices.rest.RestClient(->http://api.example.com/, timeout: [read= 60.00, connect= 2.00])",
       $this->newFixture('http://api.example.com/')->toString()
     );
   }
@@ -215,11 +215,6 @@ class RestClientTest extends TestCase {
     $fixture->setConnectTimeout(31337);
 
     $this->assertEquals(31337, $fixture->getConnectTimeout());
-  }
-
-  #[@test, @expect(IllegalStateException::class)]
-  public function setTimeoutWithoutConnectionFails() {
-    $this->newFixture()->setTimeout(31337);
   }
 
   #[@test]
@@ -244,6 +239,6 @@ class RestClientTest extends TestCase {
     $fixture= $this->newFixture();
     $fixture->setBase('http://localhost/');
 
-    $this->assertEquals(60, $fixture->getTimeout());
+    $this->assertEquals(60.0, $fixture->getTimeout());
   }
 }

--- a/src/test/php/webservices/rest/unittest/RestRequestTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestRequestTest.class.php
@@ -9,6 +9,7 @@ use webservices\rest\Payload;
 use peer\http\HttpConstants;
 use peer\http\RequestData;
 use peer\http\Header;
+use peer\URL;
 
 /**
  * TestCase
@@ -253,21 +254,21 @@ class RestRequestTest extends TestCase {
   #[@test]
   public function targetWithoutParameters() {
     $fixture= new RestRequest('/issues');
-    $this->assertEquals('/issues', $fixture->getTarget());
+    $this->assertEquals('/issues', $fixture->targetUrl(new URL('http://test'))->getPath());
   }
 
   #[@test]
   public function targetWithSegmentParameter() {
     $fixture= new RestRequest('/users/{user}');
     $fixture->addSegment('user', 'thekid');
-    $this->assertEquals('/users/thekid', $fixture->getTarget());
+    $this->assertEquals('/users/thekid', $fixture->targetUrl(new URL('http://test'))->getPath());
   }
 
   #[@test]
   public function segments_are_url_encoded() {
     $fixture= new RestRequest('/users/{user}');
     $fixture->addSegment('user', 'Timm Friebe');
-    $this->assertEquals('/users/Timm+Friebe', $fixture->getTarget());
+    $this->assertEquals('/users/Timm+Friebe', $fixture->targetUrl(new URL('http://test'))->getPath());
   }
 
   #[@test]
@@ -275,7 +276,7 @@ class RestRequestTest extends TestCase {
     $fixture= new RestRequest('/repos/{user}/{repo}');
     $fixture->addSegment('user', 'thekid');
     $fixture->addSegment('repo', 'xp-framework');
-    $this->assertEquals('/repos/thekid/xp-framework', $fixture->getTarget());
+    $this->assertEquals('/repos/thekid/xp-framework', $fixture->targetUrl(new URL('http://test'))->getPath());
   }
 
   #[@test]
@@ -284,19 +285,37 @@ class RestRequestTest extends TestCase {
     $fixture->addSegment('user', 'thekid');
     $fixture->addSegment('repo', 'xp-framework');
     $fixture->addSegment('id', 1);
-    $this->assertEquals('/repos/thekid/xp-framework/issues/1', $fixture->getTarget());
+    $this->assertEquals('/repos/thekid/xp-framework/issues/1', $fixture->targetUrl(new URL('http://test'))->getPath());
   }
 
   #[@test, @values(['/rest/api/v2/', '/rest/api/v2'])]
   public function relativeResource($base) {
     $fixture= new RestRequest('issues');
-    $this->assertEquals('/rest/api/v2/issues', $fixture->getTarget($base));
+    $this->assertEquals('/rest/api/v2/issues', $fixture->targetUrl(new URL('http://test'.$base))->getPath());
+  }
+
+  #[@test, @values(['/rest/api/v2/', '/rest/api/v2'])]
+  public function dotdotResource($base) {
+    $fixture= new RestRequest('../v3/issues');
+    $this->assertEquals('/rest/api/v2/../v3/issues', $fixture->targetUrl(new URL('http://test'.$base))->getPath());
   }
 
   #[@test, @values(['/rest/api/v2/', '/rest/api/v2'])]
   public function absoluteResource($base) {
     $fixture= new RestRequest('/issues');
-    $this->assertEquals('/rest/api/v2/issues', $fixture->getTarget($base));
+    $this->assertEquals('/issues', $fixture->targetUrl(new URL('http://test'.$base))->getPath());
+  }
+
+  #[@test]
+  public function fullResource() {
+    $fixture= new RestRequest('http://example');
+    $this->assertEquals('http://example', $fixture->targetUrl(new URL('http://test'))->getURL());
+  }
+
+  #[@test]
+  public function slashslashResource() {
+    $fixture= new RestRequest('//example');
+    $this->assertEquals('http://example', $fixture->targetUrl(new URL('http://test'))->getURL());
   }
 
   #[@test]


### PR DESCRIPTION
# Overview

In addition to the generic `execute()` method, add shortcuts. Alternative to #16

## Creating: post

```php
$client= new RestClient('http://api.example.com/');
$response= $client->post('users', ['name' => 'Test'], 'application/json');

// Check status codes
if (201 !== $response->status()) {
  throw new IllegalStateException('Could not create user!');
}

// Retrieve response headers
$url= $response->header('Location');
```

## Reading: get / head
```php
$client= new RestClient('http://api.example.com/');

// Unmarshal to object by optionally passing a type; otherwise returned as map
$user= $client->get('users/self')->data(User::class);

// Test for existance with HEAD
$exists= (200 === $client->head('users/1549')->status());

// Pass parameters
$list= $client->get('users', ['page' => 1, 'per_page' => 50])->data();
```

## Updating: put / patch
```php
$client= (new RestClient('http://api.example.com/'))
  ->using(RestFormat::$JSON)
  ->accepting(RestFormat::$JSON)
  ->with('User-Agent', 'Test')
;

// Default content type and accept types set on connection used
$updated= $client->put('users/self', ['name' => 'Tested', 'login' => $mail])->data();

// Can also use PATCH - typically used to modify only parts of the resoure
$updated= $client->patch('users/self', ['name' => 'Changed'])->data();
```

## Deleting: delete
```php
$client= new RestClient('http://api.example.com/');

// Pass segments
$client->delete(['user/{id}', 'id' => 6100]);
```

## ⚠️ Heads up

All methods now support full, absolute and relative URIs (much like your browser does!). Previously, the base path given to the constructor was always prefixed.

**This has now changed:**

```php
$client= new RestClient('http://example.com/api/v3');

// Old code, no longer accesses /api/v3/user but /user!
$client->execute(new RestRequest('/user'));

// This works correctly in both versions:
$client->execute(new RestRequest('user'));
```

## See also

https://en.wikipedia.org/wiki/Representational_state_transfer#Relationship_between_URL_and_HTTP_methods
https://github.com/rest-client/rest-client