### PR TITLE
Link header support

### DIFF
--- a/src/main/php/webservices/rest/Link.class.php
+++ b/src/main/php/webservices/rest/Link.class.php
@@ -1,0 +1,78 @@
+<?php namespace webservices\rest;
+
+use util\Objects;
+
+/**
+ * A single link inside the Links header
+ *
+ * @see  xp://webservices.rest.Links
+ * @test xp://webservices.rest.unittest.LinksTest
+ */
+class Link implements \lang\Value {
+  private $uri, $params;
+
+  /**
+   * Creates a new link
+   *
+   * @param  string $uri
+   * @param  [:string] $params
+   */
+  public function __construct($uri, $params) {
+    $this->uri= $uri;
+    $this->params= $params;
+  }
+
+  /** @return string */
+  public function uri() { return $this->uri; }
+
+  /** @return [:string] */
+  public function params() { return $this->params; }
+
+  /**
+   * Returns whether a given parameter is present
+   *
+   * @param  string $name
+   * @return bool
+   */
+  public function hasParam($name) {
+    return array_key_exists($name, $this->params);
+  }
+
+  /**
+   * Returns a given parameter's value
+   *
+   * @param  string $name
+   * @return var
+   * @throws lang.IndexOutOfBoundsException
+   */
+  public function param($name) {
+    return $this->params[$name];
+  }
+
+  /**
+   * Compares this links to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    if ($value instanceof self) {
+      return 0 === ($p= strcmp($this->uri, $value->uri)) ? Objects::compare($this->params, $value->params) : $p;
+    }
+    return 1;
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return crc32($this->uri).Objects::hashOf($this->params);
+  }
+
+  /** @return string */
+  public function toString() {
+    $s= nameof($this).'<'.$this->uri.'>';
+    foreach ($this->params as $param => $value) {
+      $s.= '; '.$param.'="'.$value.'" ';
+    }
+    return substr($s, 0, -1);
+  }
+}

--- a/src/main/php/webservices/rest/Link.class.php
+++ b/src/main/php/webservices/rest/Link.class.php
@@ -34,7 +34,7 @@ class Link implements \lang\Value {
    * @param  string $name
    * @return bool
    */
-  public function hasParam($name) {
+  public function present($name) {
     return array_key_exists($name, $this->params);
   }
 

--- a/src/main/php/webservices/rest/Links.class.php
+++ b/src/main/php/webservices/rest/Links.class.php
@@ -73,7 +73,7 @@ class Links {
     } else {
       foreach ($this->links as $link) {
         foreach ($search as $param => $compare) {
-          if (!$link->hasParam($param) || (null !== $compare && $compare !== $link->param($param))) continue 2;
+          if (!$link->present($param) || (null !== $compare && $compare !== $link->param($param))) continue 2;
         }
         yield $link;
       }
@@ -103,7 +103,7 @@ class Links {
   public function map($param) {
     $map= [];
     foreach ($this->links as $link) {
-      if ($link->hasParam($param)) $map[$link->param($param)]= $link;
+      if ($link->present($param)) $map[$link->param($param)]= $link;
     }
     return $map;
   }

--- a/src/main/php/webservices/rest/Links.class.php
+++ b/src/main/php/webservices/rest/Links.class.php
@@ -1,0 +1,110 @@
+<?php namespace webservices\rest;
+
+use text\StringTokenizer;
+use lang\FormatException;
+
+/**
+ * Link header
+ *
+ * @test xp://webservices.rest.unittest.LinksTest
+ * @see  https://www.w3.org/wiki/LinkHeader
+ * @see  https://tools.ietf.org/html/rfc5988 Web Linking
+ */
+class Links {
+  private $links= [];
+
+  /**
+   * Parser helper function
+   *
+   * @param  text.Tokenizer $st
+   * @param  string $tokens
+   * @return string
+   * @throws lang.FormatException
+   */
+  private function expect($st, $tokens) {
+    $parsed= $st->nextToken($tokens);
+    if (false === strpos($tokens, $parsed)) {
+      throw new FormatException('Expected ['.$tokens.'], have '.\xp::stringOf($parsed));
+    }
+    return $parsed;
+  }
+
+  /**
+   * Parses a Link header into a links structure
+   *
+   * @param  string $header
+   * @throws lang.FormatException If the header is malformed
+   */
+  public function __construct($header) {
+    $st= new StringTokenizer($header, '<>', true);
+    do {
+      $this->expect($st, '<');
+      $uri= $st->nextToken('>');
+      $this->expect($st, '>');
+
+      $params= [];
+      do {
+        if (',' === $this->expect($st, ';,')) break;
+
+        $param= ltrim($st->nextToken('='));
+        $this->expect($st, '=');
+        if ('"' === ($value= $st->nextToken('";,'))) {
+          $value= $st->nextToken('"');
+          $this->expect($st, '"');
+        }
+        $params[$param]= $value;
+      } while ($st->hasMoreTokens());
+
+      $this->links[]= new Link($uri, $params);
+    } while ($st->nextToken('<'));
+  }
+
+  /**
+   * Returns a map of link URIs to parameters, optionally restricted to a given search
+   *
+   * @param  [:string] $search If omitted, all links are returned
+   * @return iterable
+   */
+  public function all($search= null) {
+    if (null === $search) {
+      foreach ($this->links as $link) {
+        yield $link;
+      }
+    } else {
+      foreach ($this->links as $link) {
+        foreach ($search as $param => $compare) {
+          if (!$link->hasParam($param) || (null !== $compare && $compare !== $link->param($param))) continue 2;
+        }
+        yield $link;
+      }
+    }
+  }
+
+  /**
+   * Searches for the first link URI by a given search
+   *
+   * @param  [:string] $search
+   * @param  string $default
+   * @return string
+   */
+  public function uri($search, $default= null) {
+    foreach ($this->all($search) as $link) {
+      return $link->uri();
+    }
+    return $default;
+  }
+
+  /**
+   * Creates a lookup map to a URI by a given link parameter
+   *
+   * @param  string $param
+   * @return [:string]
+   */
+  public function map($param) {
+    $map= [];
+    foreach ($this->links as $link) {
+      if ($link->hasParam($param)) $map[$link->param($param)]= $link->uri();
+    }
+    return $map;
+  }
+}

--- a/src/main/php/webservices/rest/Links.class.php
+++ b/src/main/php/webservices/rest/Links.class.php
@@ -10,7 +10,7 @@ use lang\FormatException;
  * @see  https://www.w3.org/wiki/LinkHeader
  * @see  https://tools.ietf.org/html/rfc5988 Web Linking
  */
-class Links {
+class Links implements \lang\Value {
   private $links= [];
 
   /**
@@ -106,5 +106,29 @@ class Links {
       if ($link->present($param)) $map[$link->param($param)]= $link;
     }
     return $map;
+  }
+
+  /**
+   * Compares this links to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->links, $value->links) : 1;
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'L'.Objects::hashOf($this->links);
+  }
+
+  /** @return string */
+  public function toString() {
+    $s= nameof($this)."@[\n";
+    foreach ($this->links as $link) {
+      $s.= '  '.$link->toString()."\n";
+    }
+    return $s.']';
   }
 }

--- a/src/main/php/webservices/rest/Links.class.php
+++ b/src/main/php/webservices/rest/Links.class.php
@@ -95,15 +95,15 @@ class Links {
   }
 
   /**
-   * Creates a lookup map to a URI by a given link parameter
+   * Creates a lookup map to by a given link parameter
    *
    * @param  string $param
-   * @return [:string]
+   * @return [:webservices.rest.Link]
    */
   public function map($param) {
     $map= [];
     foreach ($this->links as $link) {
-      if ($link->hasParam($param)) $map[$link->param($param)]= $link->uri();
+      if ($link->hasParam($param)) $map[$link->param($param)]= $link;
     }
     return $map;
   }

--- a/src/test/php/webservices/rest/unittest/LinksTest.class.php
+++ b/src/test/php/webservices/rest/unittest/LinksTest.class.php
@@ -67,7 +67,11 @@ class LinksTest extends \unittest\TestCase {
   public function mapping_by_rel() {
     $links= new Links('<http://example.com/?page=3>; rel="next", <http://example.com/?page=3>; rel="last", <http://example.com/?page=1>; rel="prev"');
     $this->assertEquals(
-      ['next' => 'http://example.com/?page=3', 'last' => 'http://example.com/?page=3', 'prev' => 'http://example.com/?page=1'],
+      [
+        'next' => new Link('http://example.com/?page=3', ['rel' => 'next']),
+        'last' => new Link('http://example.com/?page=3', ['rel' => 'last']),
+        'prev' => new Link('http://example.com/?page=1', ['rel' => 'prev'])
+      ],
       $links->map('rel')
     );
   }
@@ -76,7 +80,7 @@ class LinksTest extends \unittest\TestCase {
   public function mapping_by_title_excludes_links_without_title() {
     $links= new Links('<http://example.com/?page=3>; rel="next", <http://example.com/>; title="Home"');
     $this->assertEquals(
-      ['Home' => 'http://example.com/'],
+      ['Home' => new Link('http://example.com/', ['title' => 'Home'])],
       $links->map('title')
     );
   }

--- a/src/test/php/webservices/rest/unittest/LinksTest.class.php
+++ b/src/test/php/webservices/rest/unittest/LinksTest.class.php
@@ -84,4 +84,16 @@ class LinksTest extends \unittest\TestCase {
       $links->map('title')
     );
   }
+
+  #[@test]
+  public function string_representation() {
+    $links= new Links('<http://example.com/?page=3>; rel="next", <http://example.com/>; title="Home"');
+    $this->assertEquals(
+      "webservices.rest.Links@[\n".
+      "  webservices.rest.Link<http://example.com/?page=3>; rel=\"next\"\n".
+      "  webservices.rest.Link<http://example.com/>; title=\"Home\"\n".
+      "]",
+      $links->toString()
+    );
+  }
 }

--- a/src/test/php/webservices/rest/unittest/LinksTest.class.php
+++ b/src/test/php/webservices/rest/unittest/LinksTest.class.php
@@ -1,0 +1,83 @@
+<?php namespace webservices\rest\unittest;
+
+use webservices\rest\Link;
+use webservices\rest\Links;
+use lang\FormatException;
+
+class LinksTest extends \unittest\TestCase {
+
+  #[@test, @values([
+  #  ['<http://example.com/?page=2>;rel="next"'],
+  #  ['<http://example.com/?page=2>; rel="next"'],
+  #  ['<http://example.com/?page=2>; rel="next"; hreflang=de'],
+  #  ['<http://example.com/?page=3>; rel="next", <http://example.com/?page=1>; rel="prev"'],
+  #  ['<http://example.com/?page=1>; rel="next"; title="next chapter"'],
+  #  ['<http://example.com/?page=1>; rel="next"; title="a;b"'],
+  #  ['<http://example.com/?page=1>; rel="next"; title="a,b"']
+  #])]
+  public function can_create($header) {
+    new Links($header);
+  }
+
+  #[@test, @expect(FormatException::class), @values([
+  #  [''],
+  #  ['<>'],
+  #  ['<http://example.com/?page=2'],
+  #  ['<http://example.com/?page=2>; rel'],
+  #  ['<http://example.com/?page=2>; rel="next']
+  #])]
+  public function malformed($header) {
+    new Links($header);
+  }
+
+  #[@test]
+  public function all() {
+    $links= new Links('<http://example.com/?page=2>; rel="next"');
+    $this->assertEquals([new Link('http://example.com/?page=2', ['rel' => 'next'])], iterator_to_array($links->all()));
+  }
+
+  #[@test]
+  public function all_with_rel() {
+    $links= new Links('<http://example.com/?page=2>; rel="next", <http://example.com/>; title="Home"');
+    $this->assertEquals([new Link('http://example.com/?page=2', ['rel' => 'next'])], iterator_to_array($links->all(['rel' => null])));
+  }
+
+  #[@test]
+  public function uri_by_rel() {
+    $links= new Links('<http://example.com/?page=3>; rel="next", <http://example.com/?page=1>; rel="prev"');
+    $this->assertEquals(
+      ['http://example.com/?page=1', 'http://example.com/?page=3'],
+      [$links->uri(['rel' => 'prev']), $links->uri(['rel' => 'next'])]
+    );
+  }
+
+  #[@test]
+  public function uri_by_non_existant_rel_returns_null() {
+    $links= new Links('<http://example.com/?page=2>; rel="next"');
+    $this->assertEquals(null, $links->uri(['rel' => 'prev']));
+  }
+
+  #[@test]
+  public function uri_by_non_existant_rel_returns_default() {
+    $links= new Links('<http://example.com/?page=2>; rel="next"');
+    $this->assertEquals('http://example.com', $links->uri(['rel' => 'prev'], 'http://example.com'));
+  }
+
+  #[@test]
+  public function mapping_by_rel() {
+    $links= new Links('<http://example.com/?page=3>; rel="next", <http://example.com/?page=3>; rel="last", <http://example.com/?page=1>; rel="prev"');
+    $this->assertEquals(
+      ['next' => 'http://example.com/?page=3', 'last' => 'http://example.com/?page=3', 'prev' => 'http://example.com/?page=1'],
+      $links->map('rel')
+    );
+  }
+
+  #[@test]
+  public function mapping_by_title_excludes_links_without_title() {
+    $links= new Links('<http://example.com/?page=3>; rel="next", <http://example.com/>; title="Home"');
+    $this->assertEquals(
+      ['Home' => 'http://example.com/'],
+      $links->map('title')
+    );
+  }
+}


### PR DESCRIPTION
## In a nutshell
The new `webservices.rest.Links` class will make parsing the [Link header](https://www.w3.org/wiki/LinkHeader) easy. Link headers have the following format:

```
Link: <http://example.com/?page=1>; rel="prev", <http://example.com/?page=3>; rel="next"
```

## Target
Feature without BC breaks => **8.1.0**

## Example

```php
use webservices\rest\{Endpoint, Links};
use text\json\StreamInput;
use util\cmd\Console;
use util\data\Sequence;

class GitHubApi extends Endpoint {

  public function __construct(string $token) {
    parent::__construct('https://api.github.com/');
    $this->with(['Authorization' => 'token '.$token, 'User-Agent' => nameof($this)]);
  }

  public function paged(string $resource): iterable {
    do {
      $response= $this->resource($resource)->accepting('application/json')->get();
      yield from (new StreamInput($response->stream()))->elements();

      // Here is where the Links class comes in:
      $links= new Links($response->header('Link'));
      $resource= $links->uri(['rel' => 'next']);
    } while ($resource);
  }
}

$api= new GitHubApi(getenv('GITHUB_TOKEN'));

// Passing per_page is another new feature of 8.1.0
Sequence::of($api->paged('orgs/1and1/members?per_page=50'))
  ->each(function($user) { Console::writeLine($user['type'], ' ', $user['login']); })
;
```
