### PR TITLE
Use rawurlencode() over urlencode()

### DIFF
--- a/src/main/php/webservices/rest/RestRequest.class.php
+++ b/src/main/php/webservices/rest/RestRequest.class.php
@@ -418,7 +418,7 @@ class RestRequest extends \lang\Object {
       $offset+= $b;
       if ($offset >= $l) break;
       $e= strcspn($resource, '}', $offset);
-      $target.= urlencode($this->getSegment(substr($resource, $offset+ 1, $e- 1)));
+      $target.= rawurlencode($this->getSegment(substr($resource, $offset+ 1, $e- 1)));
       $offset+= $e+ 1;
     } while ($offset < $l);
 

--- a/src/test/php/webservices/rest/unittest/RestRequestTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestRequestTest.class.php
@@ -300,7 +300,7 @@ class RestRequestTest extends TestCase {
   public function segments_are_url_encoded() {
     $fixture= new RestRequest('/users/{user}');
     $fixture->addSegment('user', 'Timm Friebe');
-    $this->assertEquals('/users/Timm+Friebe', $fixture->targetUrl(new URL('http://test'))->getPath());
+    $this->assertEquals('/users/Timm%20Friebe', $fixture->targetUrl(new URL('http://test'))->getPath());
   }
 
   #[@test]


### PR DESCRIPTION
The only difference is the encoding of the space character " " which
would be translated to "+", but actually needs to be "%20" to conform to
RFC 3986 ("Uniform Resource Identifier (URI): Generic Syntax").

There are web servers which are picky about this.