### PR TITLE
Fix GET parameters resolution

### DIFF
--- a/src/main/php/webservices/rest/RestClient.class.php
+++ b/src/main/php/webservices/rest/RestClient.class.php
@@ -190,6 +190,7 @@ class RestClient extends \lang\Object implements Traceable {
    * @param  webservices.rest.RestRequest $request
    * @return webservices.rest.RestResponse
    * @throws lang.IllegalStateException if no connection is set
+   * @throws webservices.rest.RestException
    */
   public function execute(RestRequest $request) {
     if (null === $this->connection) {

--- a/src/main/php/webservices/rest/RestClient.class.php
+++ b/src/main/php/webservices/rest/RestClient.class.php
@@ -213,7 +213,7 @@ class RestClient extends \lang\Object implements Traceable {
     } else if ($request->hasBody()) {
       $send->setParameters($request->getBody());
     } else {
-      $send->setParameters($request->getParameters());
+      $send->setParameters($request->targetParameters());
     }
     
     try {

--- a/src/main/php/webservices/rest/RestRequest.class.php
+++ b/src/main/php/webservices/rest/RestRequest.class.php
@@ -452,6 +452,15 @@ class RestRequest extends \lang\Object {
   }
 
   /**
+   * Returns parameters, resolving segments if necessary
+   *
+   * @return [:string]
+   */
+  public function targetParameters() {
+    return array_map([$this, 'resolve'], $this->parameters);
+  }
+
+  /**
    * Resolves target URL
    *
    * @param  peer.URL $base
@@ -475,7 +484,7 @@ class RestRequest extends \lang\Object {
       $url= clone $base;
     }
 
-    return $url->setParams(array_map([$this, 'resolve'], $this->parameters))->setPath($this->resolve($resource));
+    return $url->setParams($this->targetParameters())->setPath($this->resolve($resource));
   }
 
   /**

--- a/src/test/php/webservices/rest/unittest/RestRequestTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestRequestTest.class.php
@@ -320,6 +320,20 @@ class RestRequestTest extends TestCase {
     $this->assertEquals('/repos/thekid/xp-framework/issues/1', $fixture->targetUrl(new URL('http://test'))->getPath());
   }
 
+  #[@test]
+  public function segments_allowed_in_get_parameters() {
+    $fixture= new RestRequest('/repos/?user={user}');
+    $fixture->addSegment('user', 'thekid');
+    $this->assertEquals(['user' => 'thekid'], $fixture->targetUrl(new URL('http://test'))->getParams());
+  }
+
+  #[@test]
+  public function segments_in_parameters_resolved_in_target_parameters() {
+    $fixture= new RestRequest('/repos/?user={user}');
+    $fixture->addSegment('user', 'thekid');
+    $this->assertEquals(['user' => 'thekid'], $fixture->targetParameters());
+  }
+
   #[@test, @values(['/rest/api/v2/', '/rest/api/v2'])]
   public function relativeResource($base) {
     $fixture= new RestRequest('issues');


### PR DESCRIPTION
*This PR supersedes #20 which contains a possible BC break*

Example:

```php
$client= new RestClient(...);
$response= $client->execute((new RestRequest('/user?id={id}'))->withSegment('id', 1549));
```

Although `RestClient` is deprecated it should still work:)
