### PR TITLE
Added mode to allow recursive marshalling of objects

### DIFF
--- a/src/main/php/webservices/rest/RestMarshalling.class.php
+++ b/src/main/php/webservices/rest/RestMarshalling.class.php
@@ -127,8 +127,20 @@ class RestMarshalling extends \lang\Object {
       }
 
       $class= typeof($value);
+      if ($class->hasAnnotation('recursive')) {
+        $classToSearchIn= $class;
+        $fields= [];
+        do {
+          $fields= array_merge($fields, $classToSearchIn->getFields());
+        } while (
+          $classToSearchIn->hasAnnotation('recursive') &&
+          ($classToSearchIn= $classToSearchIn->getParentclass()) !== null
+        );
+      } else {
+        $fields= $class->getFields();
+      }
       $r= [];
-      foreach ($class->getFields() as $field) {
+      foreach ($fields as $field) {
         $m= $field->getModifiers();
         if ($m & MODIFIER_STATIC) {
           continue;

--- a/src/test/php/webservices/rest/unittest/ChildClass.class.php
+++ b/src/test/php/webservices/rest/unittest/ChildClass.class.php
@@ -1,0 +1,9 @@
+<?php namespace webservices\rest\unittest;
+
+/**
+ * Class ChildClass
+ */
+#[@recursive]
+class ChildClass extends ParentClassWhithPrivateFields {
+
+}

--- a/src/test/php/webservices/rest/unittest/ParentClassWhithPrivateFields.class.php
+++ b/src/test/php/webservices/rest/unittest/ParentClassWhithPrivateFields.class.php
@@ -1,0 +1,50 @@
+<?php namespace webservices\rest\unittest;
+
+use lang\Object;
+
+/**
+ * Class ParentClassWhithPrivateFields
+ */
+class ParentClassWhithPrivateFields extends ParentOfParentClassWithPrivateFields {
+
+  /** @var string */
+  private $field1;
+
+  /** @var string */
+  private $field2;
+
+  /**
+   * @return string
+   */
+  public function getField1() {
+    return 'getter_'.$this->field1;
+  }
+
+  /**
+   * @param string $field1
+   * @return $this
+   */
+  public function setField1($field1) {
+    $this->field1= $field1;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getField2() {
+    return 'getter_'.$this->field2;
+  }
+
+  /**
+   * @param string $field2
+   * @return $this
+   */
+  public function setField2($field2) {
+    $this->field2= $field2;
+    return $this;
+  }
+
+
+
+}

--- a/src/test/php/webservices/rest/unittest/ParentOfParentClassWithPrivateFields.class.php
+++ b/src/test/php/webservices/rest/unittest/ParentOfParentClassWithPrivateFields.class.php
@@ -1,0 +1,27 @@
+<?php namespace webservices\rest\unittest;
+
+use lang\Object;
+
+/**
+ * Class ParentOfParentClassWithPrivateFields
+ */
+class ParentOfParentClassWithPrivateFields extends Object {
+
+  /** @var string */
+  private $field3;
+
+  /**
+   * @return string
+   */
+  public function getField3() {
+    return $this->field3;
+  }
+
+  /**
+   * @param string $field3
+   */
+  public function setField3($field3) {
+    $this->field3= $field3;
+  }
+
+}

--- a/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace webservices\rest\unittest;
 
+use unittest\TestCase;
 use webservices\rest\TypeMarshaller;
 use lang\Object;
 use lang\Type;
@@ -19,7 +20,7 @@ use webservices\rest\RestMarshalling;
  *
  * @see   xp://webservices.rest.RestMarshalling
  */
-class RestMarshallingTest extends \unittest\TestCase {
+class RestMarshallingTest extends TestCase {
   private static $enumClass;
   private static $walletClass;
   private static $moneyMarshaller;
@@ -161,6 +162,20 @@ class RestMarshallingTest extends \unittest\TestCase {
     $this->assertEquals(
       ['issueId' => 1, 'title' => 'test'], 
       $this->fixture->marshal($issue)
+    );
+  }
+
+  #[@test]
+  public function marshal_parent_class_with_private_fields() {
+    $instance= new ChildClass();
+    $instance->setField1('val1');
+    $instance->setField2('val2');
+    $this->assertEquals(
+      [
+        'field1' => 'getter_val1',
+        'field2' => 'getter_val2'
+      ],
+      $this->fixture->marshal($instance)
     );
   }
 


### PR DESCRIPTION
If an object has private fields which can be accessed via getter functions, the marshalling (with RestMarshalling) of those fields works, but if the parent object also has such fields, it won't work.

Example:
```PHP
class Parent extends Object {
  private $foo = 'foo';

  public function getFoo() {
    return $this->foo;
  }
}

class Child extends Parent {
  private $bar= 'bar';

  public function getBar() {
    return $this->bar;
  }
}
```

Produces: 
```
[
  bar => 'bar'
]
```

But is should produce:
```
[
  foo => 'foo',
  bar => 'bar'
]
```

This pull request implements this behavior, which can be enabled by adding the ```#[@recursive]``` annotation to the child class.