### PR TITLE
XP9 Compatibility 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "xp-framework/networking": "^9.0 | ^8.0 | ^7.0 | ^6.6",
     "xp-framework/tokenize": "^8.0 | ^7.0 | ^6.5",
     "xp-forge/json": "^3.0 | ^2.1",
-    "php" : ">=5.5.0"
+    "php" : ">=5.6.0"
   },
   "require-dev" : {
     "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"

--- a/composer.json
+++ b/composer.json
@@ -6,19 +6,19 @@
   "description" : "REST Client and Server APIs for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | ^7.0 | ^6.5",
-    "xp-framework/http": "^8.0 | ^7.0 | ^6.2",
-    "xp-framework/xml": "^8.0 | ^7.0 | ^6.0",
-    "xp-framework/scriptlet": "^8.0.1",
-    "xp-framework/logging": "^7.0 | ^6.5",
-    "xp-framework/collections": "^7.0 | ^6.5",
-    "xp-framework/networking": "^8.0 | ^7.0 | ^6.6",
-    "xp-framework/tokenize": "^7.0 | ^6.5",
-    "xp-forge/json": "^2.1",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.5",
+    "xp-framework/http": "^9.0 | ^8.0 | ^7.0 | ^6.2",
+    "xp-framework/xml": "^9.0 | ^8.0 | ^7.0 | ^6.0",
+    "xp-framework/scriptlet": "^9.0 | ^8.0.1",
+    "xp-framework/logging": "^8.0 | ^7.0 | ^6.5",
+    "xp-framework/collections": "^8.0 | ^7.0 | ^6.5",
+    "xp-framework/networking": "^9.0 | ^8.0 | ^7.0 | ^6.6",
+    "xp-framework/tokenize": "^8.0 | ^7.0 | ^6.5",
+    "xp-forge/json": "^3.0 | ^2.1",
     "php" : ">=5.5.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^7.0 | ^6.5"
+    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"
+    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5",
+    "xp-framework/io-collections": "^8.0 | ^7.0 | ^6.5"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/main/php/webservices/rest/Endpoint.class.php
+++ b/src/main/php/webservices/rest/Endpoint.class.php
@@ -14,7 +14,7 @@ use peer\URL;
  * @test xp://webservices.rest.unittest.RoundtripTest
  * @test xp://webservices.rest.unittest.ExecutionTest
  */
-class Endpoint extends \lang\Object implements Traceable {
+class Endpoint implements Traceable {
   private $base;
   private $connectionTo;
   private $marshalling;

--- a/src/main/php/webservices/rest/Iteration.class.php
+++ b/src/main/php/webservices/rest/Iteration.class.php
@@ -6,7 +6,7 @@
  *
  * @see  php://traversable
  */
-class Iteration extends \lang\Object implements \Iterator {
+class Iteration implements \Iterator {
   protected $it, $mapping;
 
   /**

--- a/src/main/php/webservices/rest/Payload.class.php
+++ b/src/main/php/webservices/rest/Payload.class.php
@@ -1,14 +1,14 @@
 <?php namespace webservices\rest;
 
 use util\Objects;
-
+use lang\Value;
 
 /**
  * Represents the REST payload
  *
  * @test  xp://net.xp_framework.unittest.webservices.rest.PayloadTest
  */
-class Payload {
+class Payload implements Value {
   public $value, $properties;
 
   /**
@@ -22,17 +22,30 @@ class Payload {
     $this->properties= $properties;
   }
 
+  /** @return string */
+  public function hashCode() {
+    return 'O'.Objects::hashOf([$this->value, $this->properties]);
+  }
+
+  /** @return string */
+  public function toString() {
+    $p= '';
+    foreach ($this->properties as $key => $value) {
+      $p.= ', '.$key.'= '.$value;
+    }
+    return nameof($this).'('.substr($p, 2).")@{\n".str_replace("\n", "\n  ", Objects::stringOf($this->value))."\n}";
+  }
+
   /**
-   * Returns whether a given value is equal to this payload
-   * 
-   * @param  var cmp
-   * @return bool
+   * Compares this output to a given value
+   *
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return (
-      $cmp instanceof self && 
-      Objects::equal($cmp->value, $this->value) &&
-      $this->properties === $cmp->properties
-    );
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare([$this->value, $this->properties], [$value->value, $value->properties])
+      : 1
+    ;
   }
 }

--- a/src/main/php/webservices/rest/Payload.class.php
+++ b/src/main/php/webservices/rest/Payload.class.php
@@ -8,7 +8,7 @@ use util\Objects;
  *
  * @test  xp://net.xp_framework.unittest.webservices.rest.PayloadTest
  */
-class Payload extends \lang\Object {
+class Payload {
   public $value, $properties;
 
   /**

--- a/src/main/php/webservices/rest/ResponseReader.class.php
+++ b/src/main/php/webservices/rest/ResponseReader.class.php
@@ -5,7 +5,7 @@
  *
  * @test   xp://webservices.rest.unittest.ResponseReaderTest
  */
-class ResponseReader extends \lang\Object {
+class ResponseReader {
   protected $deserializer;
   protected $marshalling;
 

--- a/src/main/php/webservices/rest/RestClient.class.php
+++ b/src/main/php/webservices/rest/RestClient.class.php
@@ -14,7 +14,7 @@ use lang\XPClass;
  * @test xp://webservices.rest.unittest.RestClientTest
  * @test xp://webservices.rest.unittest.RestClientSendTest
  */
-class RestClient extends \lang\Object implements Traceable {
+class RestClient implements Traceable {
   protected $connection= null;
   protected $cat= null;
   protected $serializers= [];

--- a/src/main/php/webservices/rest/RestClient.class.php
+++ b/src/main/php/webservices/rest/RestClient.class.php
@@ -237,6 +237,10 @@ class RestClient extends \lang\Object implements Traceable {
    * @return string
    */
   public function toString() {
-    return nameof($this).'(->'.\xp::stringOf($this->connection).')';
+    if ($this->connection) {
+      return nameof($this).'(->'.$this->connection->toString().')';
+    } else {
+      return nameof($this).'(->null)';
+    }
   }
 }

--- a/src/main/php/webservices/rest/RestDeserializer.class.php
+++ b/src/main/php/webservices/rest/RestDeserializer.class.php
@@ -9,7 +9,7 @@
  * @see   xp://webservices.rest.RestXmlDeserializer
  * @see   xp://webservices.rest.RestFormDeserializer
  */
-abstract class RestDeserializer extends \lang\Object {
+abstract class RestDeserializer {
 
   /**
    * Deserialize

--- a/src/main/php/webservices/rest/RestMarshalling.class.php
+++ b/src/main/php/webservices/rest/RestMarshalling.class.php
@@ -14,7 +14,7 @@ use lang\ClassLoader;
  *
  * @test  xp://net.xp_framework.unittest.webservices.rest.RestMarshallingTest
  */
-class RestMarshalling extends \lang\Object {
+class RestMarshalling {
   protected $marshallers;
 
   /**

--- a/src/main/php/webservices/rest/RestRequest.class.php
+++ b/src/main/php/webservices/rest/RestRequest.class.php
@@ -11,7 +11,7 @@ use peer\URL;
  *
  * @test    xp://net.xp_framework.unittest.webservices.rest.RestRequestTest
  */
-class RestRequest extends \lang\Object {
+class RestRequest {
   protected $resource= '/';
   protected $method= '';
   protected $contentType= null;

--- a/src/main/php/webservices/rest/RestResource.class.php
+++ b/src/main/php/webservices/rest/RestResource.class.php
@@ -1,6 +1,6 @@
 <?php namespace webservices\rest;
 
-class RestResource extends \lang\Object {
+class RestResource {
   private $client, $request;
 
   /**

--- a/src/main/php/webservices/rest/RestResponse.class.php
+++ b/src/main/php/webservices/rest/RestResponse.class.php
@@ -9,7 +9,7 @@ use peer\http\HttpResponse;
  *
  * @test    xp://net.xp_framework.unittest.webservices.rest.RestResponseTest
  */
-class RestResponse extends \lang\Object {
+class RestResponse {
   protected $response= null;
   protected $reader= null;
   protected $input= null;

--- a/src/main/php/webservices/rest/RestSerializer.class.php
+++ b/src/main/php/webservices/rest/RestSerializer.class.php
@@ -8,7 +8,7 @@
  * @see   xp://webservices.rest.RestJsonSerializer
  * @see   xp://webservices.rest.RestXmlSerializer
  */
-abstract class RestSerializer extends \lang\Object {
+abstract class RestSerializer {
 
   /**
    * Return the Content-Type header's value

--- a/src/main/php/webservices/rest/RestXmlMap.class.php
+++ b/src/main/php/webservices/rest/RestXmlMap.class.php
@@ -7,7 +7,7 @@ use xml\Node;
  * Wraps an xml.Node into an array-acessible form
  *
  */
-class RestXmlMap extends \lang\Object implements \IteratorAggregate, \ArrayAccess {
+class RestXmlMap implements \IteratorAggregate, \ArrayAccess {
   protected $node= null;
 
   protected static $iterate= null;

--- a/src/main/php/webservices/rest/UnknownFormat.class.php
+++ b/src/main/php/webservices/rest/UnknownFormat.class.php
@@ -6,7 +6,7 @@ use io\streams\OutputStream;
 /**
  * Unknown format. Raises exceptions when reading / writing.
  */
-class UnknownFormat extends \lang\Object implements Format {
+class UnknownFormat implements Format {
   private $mediatype;
 
   /** @param string mediatype */

--- a/src/main/php/webservices/rest/srv/AbstractRestRouter.class.php
+++ b/src/main/php/webservices/rest/srv/AbstractRestRouter.class.php
@@ -8,7 +8,7 @@ use scriptlet\Preference;
  *
  * @test  xp://net.xp_framework.unittest.webservices.rest.srv.AbstractRestRouterTest
  */
-class AbstractRestRouter extends \lang\Object {
+class AbstractRestRouter {
   protected $cat= null;
   protected $routes= [];
   protected $input= [];

--- a/src/main/php/webservices/rest/srv/DefaultExceptionMapper.class.php
+++ b/src/main/php/webservices/rest/srv/DefaultExceptionMapper.class.php
@@ -5,7 +5,7 @@
  * context's marshalling for exceptions.
  *
  */
-class DefaultExceptionMapper extends \lang\Object implements ExceptionMapper {
+class DefaultExceptionMapper implements ExceptionMapper {
   protected $statusCode;
 
   /**

--- a/src/main/php/webservices/rest/srv/DefaultExceptionMarshaller.class.php
+++ b/src/main/php/webservices/rest/srv/DefaultExceptionMarshaller.class.php
@@ -10,7 +10,7 @@ use webservices\rest\TypeMarshaller;
  *   { "message" : "Exception message" }
  * </code>
  */
-class DefaultExceptionMarshaller extends \lang\Object implements TypeMarshaller {
+class DefaultExceptionMarshaller implements TypeMarshaller {
 
   /**
    * Marshals the type

--- a/src/main/php/webservices/rest/srv/Output.class.php
+++ b/src/main/php/webservices/rest/srv/Output.class.php
@@ -2,11 +2,12 @@
 
 use scriptlet\Cookie;
 use util\Objects;
+use lang\Value;
 
 /**
  * Represents output
  */
-abstract class Output {
+abstract class Output implements Value {
   public $status;
   public $headers= [];
   public $cookies= [];
@@ -92,18 +93,36 @@ abstract class Output {
     return true;
   }
 
+  /** @return string */
+  public function hashCode() {
+    return 'O'.Objects::hashOf([$this->status, $this->headers, $this->cookies]);
+  }
+
+  /** @return string */
+  public function toString() {
+    $s= nameof($this).'(status= '.$this->status.")@{\n";
+    foreach ($this->headers as $name => $value) {
+      $s.= '  '.$name.': '.$value."\n";
+    }
+    foreach ($this->cookies as $cookie) {
+      $s.= '  Cookie: '.$cookie->toString()."\n";
+    }
+    return $s.'}';
+  }
+
   /**
-   * Returns whether a given value is equal to this Response instance
+   * Compares this output to a given value
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return (
-      $cmp instanceof self &&
-      $this->status === $cmp->status &&
-      Objects::equal($this->headers, $cmp->headers) &&
-      Objects::equal($this->cookies, $cmp->cookies)
-    );
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare(
+        [$this->status, $this->headers, $this->cookies],
+        [$value->status, $value->headers, $value->cookies]
+      )
+      : 1
+    ;
   }
 }

--- a/src/main/php/webservices/rest/srv/Output.class.php
+++ b/src/main/php/webservices/rest/srv/Output.class.php
@@ -6,7 +6,7 @@ use util\Objects;
 /**
  * Represents output
  */
-abstract class Output extends \lang\Object {
+abstract class Output {
   public $status;
   public $headers= [];
   public $cookies= [];

--- a/src/main/php/webservices/rest/srv/Response.class.php
+++ b/src/main/php/webservices/rest/srv/Response.class.php
@@ -1,5 +1,6 @@
 <?php namespace webservices\rest\srv;
 
+use util\Objects;
 use webservices\rest\Payload;
 use webservices\rest\RestFormat;
 
@@ -193,15 +194,16 @@ class Response extends Output {
   }
 
   /**
-   * Returns whether a given value is equal to this Response instance
+   * Compares this output to a given value
    *
-   * @param  var cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return (
-      parent::equals($cmp) &&
-      (null === $this->payload ? null === $cmp->payload : $this->payload->equals($cmp->payload))
-    );
+  public function compareTo($value) {
+    if ($value instanceof self) {
+      if (0 !== ($c= parent::compareTo($value))) return $c;
+      return Objects::compare($this->payload, $value->payload);
+    }
+    return 1;
   }
 }

--- a/src/main/php/webservices/rest/srv/RestContext.class.php
+++ b/src/main/php/webservices/rest/srv/RestContext.class.php
@@ -23,7 +23,7 @@ use lang\reflect\TargetInvocationException;
  * @test  xp://net.xp_framework.unittest.webservices.rest.srv.RestContextTest
  * @test  xp://net.xp_framework.unittest.webservices.rest.srv.RestContextHandleTest
  */
-class RestContext extends \lang\Object implements \util\log\Traceable {
+class RestContext implements \util\log\Traceable {
   protected $mappers;
   protected $marshalling;
   protected $cat= null;

--- a/src/main/php/webservices/rest/srv/RestParamSource.class.php
+++ b/src/main/php/webservices/rest/srv/RestParamSource.class.php
@@ -6,7 +6,7 @@
  * Parameter source
  *
  */
-class RestParamSource extends \lang\Object {
+class RestParamSource {
   public $name;
   public $reader;
 

--- a/src/main/php/webservices/rest/srv/RestRoute.class.php
+++ b/src/main/php/webservices/rest/srv/RestRoute.class.php
@@ -5,7 +5,7 @@
  *
  * @test  xp://net.xp_framework.unittest.webservices.rest.srv.RestRouteTest
  */
-class RestRoute extends \lang\Object {
+class RestRoute {
   protected $verb= '';
   protected $path= '';
   protected $handler= null;

--- a/src/main/php/webservices/rest/srv/StreamingOutput.class.php
+++ b/src/main/php/webservices/rest/srv/StreamingOutput.class.php
@@ -147,17 +147,19 @@ class StreamingOutput extends Output {
   }
 
   /**
-   * Returns whether a given value is equal to this Response instance
+   * Compares this output to a given value
    *
-   * @param  var cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return (
-      parent::equals($cmp) &&
-      $this->mediaType === $cmp->mediaType &&
-      $this->contentLength === $cmp->contentLength &&
-      Objects::equal($this->inputStream, $cmp->inputStream)
-    );
+  public function compareTo($value) {
+    if ($value instanceof self) {
+      if (0 !== ($c= parent::compareTo($value))) return $c;
+      return Objects::compare(
+        [$this->mediaType, $this->contentLength, $this->inputStream],
+        [$value->mediaType, $value->contentLength, $value->inputStream]
+      );
+    }
+    return 1;
   }
 }

--- a/src/main/php/webservices/rest/srv/paging/LinkHeader.class.php
+++ b/src/main/php/webservices/rest/srv/paging/LinkHeader.class.php
@@ -8,7 +8,7 @@ use util\Objects;
  *
  * @see   http://tools.ietf.org/html/rfc5988#page-6
  */
-class LinkHeader extends \lang\Object {
+class LinkHeader {
   private $links= [];
 
   /**

--- a/src/main/php/webservices/rest/srv/paging/PageParameters.class.php
+++ b/src/main/php/webservices/rest/srv/paging/PageParameters.class.php
@@ -9,7 +9,7 @@
  *
  * @test  xp://webservices.rest.unittest.srv.paging.UrlParametersTest
  */
-class PageParameters extends \lang\Object implements Behavior {
+class PageParameters implements Behavior {
   private $page, $limit;
 
   /**

--- a/src/main/php/webservices/rest/srv/paging/Pagination.class.php
+++ b/src/main/php/webservices/rest/srv/paging/Pagination.class.php
@@ -9,7 +9,7 @@ use scriptlet\Request;
  *
  * @test  xp://webservices.rest.unittest.srv.paging.PaginationTest
  */
-class Pagination extends \lang\Object {
+class Pagination {
   private $request, $size, $behavior;
 
   /**

--- a/src/main/php/webservices/rest/srv/paging/Paging.class.php
+++ b/src/main/php/webservices/rest/srv/paging/Paging.class.php
@@ -2,7 +2,7 @@
 
 use util\NoSuchElementException;
 
-class Paging extends \lang\Object {
+class Paging {
   private $size, $behaviors;
 
   /**

--- a/src/test/php/webservices/rest/unittest/ConstructorFixture.class.php
+++ b/src/test/php/webservices/rest/unittest/ConstructorFixture.class.php
@@ -6,7 +6,7 @@
  * Issues
  *
  */
-abstract class ConstructorFixture extends \lang\Object {
+abstract class ConstructorFixture {
   public $id= 0;
 
   /**

--- a/src/test/php/webservices/rest/unittest/IssueWithField.class.php
+++ b/src/test/php/webservices/rest/unittest/IssueWithField.class.php
@@ -6,7 +6,7 @@
  * Issue
  *
  */
-class IssueWithField extends \lang\Object {
+class IssueWithField {
   #[@type('int')]
   public $issueId= 0;
   #[@type('string')]

--- a/src/test/php/webservices/rest/unittest/IssueWithGetter.class.php
+++ b/src/test/php/webservices/rest/unittest/IssueWithGetter.class.php
@@ -9,7 +9,7 @@ use util\Date;
  * Issue
  *
  */
-class IssueWithGetter extends \lang\Object {
+class IssueWithGetter {
   protected $issueId= 0;
   protected $title= null;
   protected $createdAt= null;

--- a/src/test/php/webservices/rest/unittest/IssueWithSetter.class.php
+++ b/src/test/php/webservices/rest/unittest/IssueWithSetter.class.php
@@ -6,7 +6,7 @@
  * Issue
  *
  */
-class IssueWithSetter extends \lang\Object {
+class IssueWithSetter {
   protected $issueId= 0;
   protected $title= null;
   

--- a/src/test/php/webservices/rest/unittest/IssueWithUnderscoreField.class.php
+++ b/src/test/php/webservices/rest/unittest/IssueWithUnderscoreField.class.php
@@ -6,7 +6,7 @@
  * Issue
  *
  */
-class IssueWithUnderscoreField extends \lang\Object {
+class IssueWithUnderscoreField {
   public $issue_id= 0;
   public $title= null;
   

--- a/src/test/php/webservices/rest/unittest/IssueWithUnderscoreFieldsAndGetter.class.php
+++ b/src/test/php/webservices/rest/unittest/IssueWithUnderscoreFieldsAndGetter.class.php
@@ -1,15 +1,12 @@
 <?php namespace webservices\rest\unittest;
 
-
-
 use util\Date;
-
 
 /**
  * Issue
  *
  */
-class IssueWithUnderscoreFieldsAndGetter extends \lang\Object {
+class IssueWithUnderscoreFieldsAndGetter {
   protected $issue_id= 0;
   protected $title= null;
   protected $created_at= null;

--- a/src/test/php/webservices/rest/unittest/IssueWithUnderscoreSetter.class.php
+++ b/src/test/php/webservices/rest/unittest/IssueWithUnderscoreSetter.class.php
@@ -6,7 +6,7 @@
  * Issue
  *
  */
-class IssueWithUnderscoreSetter extends \lang\Object {
+class IssueWithUnderscoreSetter {
   protected $issue_id= 0;
   protected $title= null;
   

--- a/src/test/php/webservices/rest/unittest/Issues.class.php
+++ b/src/test/php/webservices/rest/unittest/Issues.class.php
@@ -1,6 +1,6 @@
 <?php namespace webservices\rest\unittest;
 
-class Issues extends \lang\Object {
+class Issues {
   private $backing= null;
 
   /**

--- a/src/test/php/webservices/rest/unittest/IssuesWithField.class.php
+++ b/src/test/php/webservices/rest/unittest/IssuesWithField.class.php
@@ -6,7 +6,7 @@
  * Issues
  *
  */
-class IssuesWithField extends \lang\Object {
+class IssuesWithField {
   #[@type('webservices.rest.unittest.IssueWithField[]')]
   public $issues= null;
 

--- a/src/test/php/webservices/rest/unittest/IssuesWithSetter.class.php
+++ b/src/test/php/webservices/rest/unittest/IssuesWithSetter.class.php
@@ -4,7 +4,7 @@
  * Issues
  *
  */
-class IssuesWithSetter extends \lang\Object {
+class IssuesWithSetter {
   protected $issues= null;
 
   /**

--- a/src/test/php/webservices/rest/unittest/PayloadTest.class.php
+++ b/src/test/php/webservices/rest/unittest/PayloadTest.class.php
@@ -54,7 +54,7 @@ class PayloadTest extends TestCase {
 
   #[@test]
   public function different_object_payloads_are_not_equal() {
-    $this->assertNotEquals(new Payload($this), new Payload(new \lang\Object()));
+    $this->assertNotEquals(new Payload($this), new Payload(newinstance(Value::class, [])));
   }
 
   #[@test]

--- a/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
@@ -415,7 +415,7 @@ class RestMarshallingTest extends \unittest\TestCase {
     $issue= new IssueWithField(1, 'test');
     $this->assertEquals(
       $issue, 
-      $this->fixture->unmarshal($issue->getClass(), ['issue_id' => 1, 'title' => 'test'])
+      $this->fixture->unmarshal(typeof($issue), ['issue_id' => 1, 'title' => 'test'])
     );
   }
 
@@ -424,7 +424,7 @@ class RestMarshallingTest extends \unittest\TestCase {
     $issue= new IssueWithUnderscoreField(1, 'test');
     $this->assertEquals(
       $issue, 
-      $this->fixture->unmarshal($issue->getClass(), ['issue_id' => 1, 'title' => 'test'])
+      $this->fixture->unmarshal(typeof($issue), ['issue_id' => 1, 'title' => 'test'])
     );
   }
 
@@ -433,7 +433,7 @@ class RestMarshallingTest extends \unittest\TestCase {
     $issue= new IssueWithSetter(1, 'test');
     $this->assertEquals(
       $issue, 
-      $this->fixture->unmarshal($issue->getClass(), ['issue_id' => 1, 'title' => 'test'])
+      $this->fixture->unmarshal(typeof($issue), ['issue_id' => 1, 'title' => 'test'])
     );
   }
 
@@ -442,7 +442,7 @@ class RestMarshallingTest extends \unittest\TestCase {
     $issue= new IssueWithUnderscoreSetter(1, 'test');
     $this->assertEquals(
       $issue, 
-      $this->fixture->unmarshal($issue->getClass(), ['issue_id' => 1, 'title' => 'test'])
+      $this->fixture->unmarshal(typeof($issue), ['issue_id' => 1, 'title' => 'test'])
     );
   }
 
@@ -479,7 +479,7 @@ class RestMarshallingTest extends \unittest\TestCase {
   #[@test]
   public function unmarshal_already_instance_of() {
     $issue= new IssueWithField(1, 'test1');
-    $this->assertEquals($issue, $this->fixture->unmarshal($issue->getClass(), $issue));
+    $this->assertEquals($issue, $this->fixture->unmarshal(typeof($issue), $issue));
   }
 
   #[@test]

--- a/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
+++ b/src/test/php/webservices/rest/unittest/RestMarshallingTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace webservices\rest\unittest;
 
 use webservices\rest\TypeMarshaller;
-use lang\Object;
 use lang\Type;
 use lang\Primitive;
 use lang\ArrayType;
@@ -13,6 +12,7 @@ use util\TimeZone;
 use util\Money;
 use util\Currency;
 use webservices\rest\RestMarshalling;
+use webservices\rest\unittest\srv\fixture\Wallet;
 
 /**
  * TestCase
@@ -49,20 +49,8 @@ class RestMarshallingTest extends \unittest\TestCase {
   }
 
   #[@beforeClass]
-  public static function defineWalletClassAndMarshaller() {
-    self::$walletClass= ClassLoader::defineClass('Wallet', 'lang.Object', [], '{
-      public $values= [];
-      public function __construct($values= []) {
-        $this->values= $values;
-      }
-      public function add(\util\Money $m) {
-        $this->values[]= $m;
-        return $this;
-      }
-      public function equals($cmp) {
-        return $cmp instanceof self && \util\Objects::equal($cmp->values, $this->values);
-      }
-    }');
+  public static function defineWalletClassMarshaller() {
+    self::$walletClass= new XPClass(Wallet::class);
     self::$walletMarshaller= newinstance(TypeMarshaller::class, [], [
       'marshal' => function($wallet, $marshalling= null) {
         return $marshalling->marshal($wallet->values);
@@ -199,7 +187,7 @@ class RestMarshallingTest extends \unittest\TestCase {
 
   #[@test]
   public function marshal_static_member_excluded() {
-    $o= newinstance(Object::class, [], '{
+    $o= newinstance(Value::class, [], '{
       public $name= "Test";
       public static $instance;
     }');
@@ -496,7 +484,7 @@ class RestMarshallingTest extends \unittest\TestCase {
   #  [['id' => 4711, 'name' => 'Test']]
   #])]
   public function unmarshal_static_valueof_method($input) {
-    $class= ClassLoader::defineClass('RestConversionTest_StaticValueOf', 'lang.Object', [], '{
+    $class= ClassLoader::defineClass('RestConversionTest_StaticValueOf', Value::class, [], '{
       public $passed;
       public static function valueOf($args) { $self= new self(); $self->passed= $args; return $self; }
     }');
@@ -511,7 +499,7 @@ class RestMarshallingTest extends \unittest\TestCase {
   #  [['id' => 4711, 'name' => 'Test']]
   #])]
   public function unmarshal_static_valueof_method_with_array_param($input) {
-    $class= ClassLoader::defineClass('RestConversionTest_StaticValueOfWithArrayParam', 'lang.Object', [], '{
+    $class= ClassLoader::defineClass('RestConversionTest_StaticValueOfWithArrayParam', Value::class, [], '{
       public $passed;
       public static function valueOf(array $args) { $self= new self(); $self->passed= $args; return $self; }
     }');
@@ -539,7 +527,7 @@ class RestMarshallingTest extends \unittest\TestCase {
   #  [['id' => 4711, 'name' => 'Test']]
   #])]
   public function unmarshal_static_valueof_method_with_multiple_params($input) {
-    $class= ClassLoader::defineClass('RestConversionTest_StaticValueOfWithMultipleParams', 'lang.Object', [], '{
+    $class= ClassLoader::defineClass('RestConversionTest_StaticValueOfWithMultipleParams', Value::class, [], '{
       public $passed;
       public static function valueOf($id, $name) { $self= new self(); $self->passed= [$id, $name]; return $self; }
     }');
@@ -598,15 +586,12 @@ class RestMarshallingTest extends \unittest\TestCase {
 
   #[@test]
   public function unmarshal_static_member_excluded() {
-    $class= ClassLoader::defineClass('RestConversionTest_StaticMemberExcluded', 'lang.Object', [], '{
+    $class= ClassLoader::defineClass('RestConversionTest_StaticMemberExcluded', Value::class, [], '{
       public $name;
       public static $instance= null;
     }');
-    $this->assertnull($this->fixture->unmarshal($class, ['name' => 'Test', 'instance' => 'Value'])
-      ->getClass()
-      ->getField('instance')
-      ->get(null)
-    );
+    $instance= $this->fixture->unmarshal($class, ['name' => 'Test', 'instance' => 'Value']);
+    $this->assertNull(typeof($instance)->getField('instance')->get(null));
   }
 
   #[@test]

--- a/src/test/php/webservices/rest/unittest/Value.class.php
+++ b/src/test/php/webservices/rest/unittest/Value.class.php
@@ -1,0 +1,5 @@
+<?php namespace webservices\rest\unittest;
+
+abstract class Value {
+
+}

--- a/src/test/php/webservices/rest/unittest/srv/AbstractRestRouterTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/AbstractRestRouterTest.class.php
@@ -17,22 +17,16 @@ class AbstractRestRouterTest extends TestCase {
   protected $target= null;
   protected $handler= null;
 
-  /**
-   * Setup
-   * 
-   */
+  /** @return void */
   public function setUp() {
     $this->fixture= new AbstractRestRouter();
     $this->fixture->setInputFormats(['*json']);
     $this->fixture->setOutputFormats(['text/json']);
-    $this->handler= $this->getClass();
+    $this->handler= typeof($this);
     $this->target= $this->handler->getMethod('target');
   }
 
-  /**
-   * Target method
-   *
-   */
+  /** @return void */
   #[@webservice]
   public function target() {
     // Intentionally empty

--- a/src/test/php/webservices/rest/unittest/srv/Handler.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/Handler.class.php
@@ -1,0 +1,5 @@
+<?php namespace webservices\rest\unittest\srv;
+
+abstract class Handler {
+
+}

--- a/src/test/php/webservices/rest/unittest/srv/ResponseTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/ResponseTest.class.php
@@ -5,6 +5,7 @@ use webservices\rest\Payload;
 use scriptlet\Cookie;
 use scriptlet\HttpScriptletResponse;
 use peer\URL;
+use webservices\rest\unittest\srv\fixture\Greeting;
 
 /**
  * Test response class
@@ -237,12 +238,9 @@ class ResponseTest extends \unittest\TestCase {
 
   #[@test]
   public function equals_same_object_payloads() {
-    $class= \lang\ClassLoader::defineClass('ResponseTest_SameObjectFixture', 'lang.Object', [], '{
-      public function equals($cmp) { return TRUE; }
-    }');
     $this->assertEquals(
-      Response::status(200)->withPayload($class->newInstance()), 
-      Response::status(200)->withPayload($class->newInstance())
+      Response::status(200)->withPayload(new Greeting('Hello', 'World')), 
+      Response::status(200)->withPayload(new Greeting('Hello', 'World'))
     );
   }
 
@@ -250,7 +248,7 @@ class ResponseTest extends \unittest\TestCase {
   public function equals_different_object_payloads() {
     $this->assertNotEquals(
       Response::status(200)->withPayload($this), 
-      Response::status(200)->withPayload(new \lang\Object())
+      Response::status(200)->withPayload(new Greeting('Hello', 'World'))
     );
   }
 

--- a/src/test/php/webservices/rest/unittest/srv/RestContextHandleTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/RestContextHandleTest.class.php
@@ -1,6 +1,5 @@
 <?php namespace webservices\rest\unittest\srv;
 
-use lang\Object;
 use webservices\rest\srv\RestContext;
 use webservices\rest\srv\Response;
 use webservices\rest\Payload;
@@ -33,7 +32,7 @@ class RestContextHandleTest extends \unittest\TestCase {
 
   #[@test]
   public function primitive_return() {
-    $handler= newinstance(Object::class, [], '{
+    $handler= newinstance(Handler::class, [], '{
       #[@webmethod(verb= "GET")]
       public function fixture() { return "Hello World"; }
     }');
@@ -45,7 +44,7 @@ class RestContextHandleTest extends \unittest\TestCase {
 
   #[@test]
   public function response_instance_return() {
-    $handler= newinstance(Object::class, [], '{
+    $handler= newinstance(Handler::class, [], '{
       #[@webmethod(verb= "GET")]
       public function fixture() { return \webservices\rest\srv\Response::created("/resource/4711"); }
     }');
@@ -57,7 +56,7 @@ class RestContextHandleTest extends \unittest\TestCase {
 
   #[@test]
   public function void_return() {
-    $handler= newinstance(Object::class, [], '{
+    $handler= newinstance(Handler::class, [], '{
       /** @return void **/
       #[@webmethod(verb= "GET")]
       public function fixture() { /* Intentionally empty */ }
@@ -70,7 +69,7 @@ class RestContextHandleTest extends \unittest\TestCase {
 
   #[@test]
   public function void_return_ignores_return_value() {
-    $handler= newinstance(Object::class, [], '{
+    $handler= newinstance(Handler::class, [], '{
       /** @return void **/
       #[@webmethod(verb= "GET")]
       public function fixture() { return "Something"; }
@@ -83,7 +82,7 @@ class RestContextHandleTest extends \unittest\TestCase {
 
   #[@test]
   public function null_return() {
-    $handler= newinstance(Object::class, [], '{
+    $handler= newinstance(Handler::class, [], '{
       #[@webmethod(verb= "GET")]
       public function fixture() { return null; }
     }');
@@ -95,7 +94,7 @@ class RestContextHandleTest extends \unittest\TestCase {
 
   #[@test]
   public function no_return() {
-    $handler= newinstance(Object::class, [], '{
+    $handler= newinstance(Handler::class, [], '{
       #[@webmethod(verb= "GET")]
       public function fixture() { return; }
     }');
@@ -115,7 +114,7 @@ class RestContextHandleTest extends \unittest\TestCase {
   #  [501, MethodNotImplementedException::class]
   #])]
   public function raised_exception($status, $exception) {
-    $handler= newinstance(Object::class, [$exception], [
+    $handler= newinstance(Handler::class, [$exception], [
       'exception' => null,
       '__construct' => function($exception) {
         $this->exception= $exception;

--- a/src/test/php/webservices/rest/unittest/srv/RestContextHandleTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/RestContextHandleTest.class.php
@@ -28,7 +28,7 @@ class RestContextHandleTest extends \unittest\TestCase {
    * @return webservices.rest.srv.Response
    */
   protected function handle($instance, $args= []) {
-    return (new RestContext())->handle($instance, $instance->getClass()->getMethod('fixture'), $args);
+    return (new RestContext())->handle($instance, typeof($instance)->getMethod('fixture'), $args);
   }
 
   #[@test]

--- a/src/test/php/webservices/rest/unittest/srv/RestContextTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/RestContextTest.class.php
@@ -11,6 +11,7 @@ use webservices\rest\srv\RestContext;
 use util\log\Logger;
 use util\log\LogCategory;
 use lang\reflect\Package;
+use webservices\rest\unittest\srv\fixture\Greeting;
 
 /**
  * Test default router
@@ -118,34 +119,34 @@ class RestContextTest extends TestCase {
   }
 
   #[@test]
-  public function marshal_this_with_typemarshaller() {
-    $this->fixture->addMarshaller('unittest.TestCase', newinstance(TypeMarshaller::class, [], '{
+  public function marshal_greeting_with_typemarshaller() {
+    $this->fixture->addMarshaller(Greeting::class, newinstance(TypeMarshaller::class, [], '{
       public function marshal($t) {
-        return $t->getName();
+        return $t->name;
       }
       public function unmarshal(\lang\Type $target, $name) {
         // Not needed
       }
     }'));
     $this->assertEquals(
-      new \webservices\rest\Payload($this->getName()),
-      $this->fixture->marshal(new \webservices\rest\Payload($this))
+      new \webservices\rest\Payload('World'),
+      $this->fixture->marshal(new \webservices\rest\Payload(new Greeting('Hello', 'World')))
     );
   }
 
   #[@test]
-  public function unmarshal_this_with_typemarshaller() {
-    $this->fixture->addMarshaller('unittest.TestCase', newinstance(TypeMarshaller::class, [], '{
+  public function unmarshal_greeting_with_typemarshaller() {
+    $this->fixture->addMarshaller(Greeting::class, newinstance(TypeMarshaller::class, [], '{
       public function marshal($t) {
         // Not needed
       }
-      public function unmarshal(\lang\Type $target, $name) {
-        return $target->newInstance($name);
+      public function unmarshal(\lang\Type $target, $value) {
+        return $target->newInstance("Hello", $value);
       }
     }'));
     $this->assertEquals(
-      $this,
-      $this->fixture->unmarshal($this->getClass(), $this->getName())
+      new Greeting('Hello', 'World'),
+      $this->fixture->unmarshal(\lang\Type::forName(Greeting::class), 'World')
     );
   }
 
@@ -159,7 +160,7 @@ class RestContextTest extends TestCase {
     }');
     $this->assertEquals(
       \webservices\rest\srv\Response::error(200)->withPayload(new \webservices\rest\Payload(['isbn' => '978-3-16-148410-0', 'author' => 'Test'], ['name' => 'book'])),
-      $this->fixture->handle($handler, $handler->getClass()->getMethod('getBook'), [])
+      $this->fixture->handle($handler, typeof($handler)->getMethod('getBook'), [])
     );
   }
 
@@ -171,7 +172,7 @@ class RestContextTest extends TestCase {
     }');
     $this->assertEquals(
       \webservices\rest\srv\Response::error(200)->withPayload(new \webservices\rest\Payload('Test', ['name' => 'greeting'])),
-      $this->fixture->handle($handler, $handler->getClass()->getMethod('greet'), [])
+      $this->fixture->handle($handler, typeof($handler)->getMethod('greet'), [])
     );
   }
 
@@ -190,7 +191,7 @@ class RestContextTest extends TestCase {
     }'));
     $this->assertEquals(
       \webservices\rest\srv\Response::status(500)->withPayload(new \webservices\rest\Payload(['message' => 'Test'], ['name' => 'exception'])),
-      $this->fixture->handle($this, $this->getClass()->getMethod('raiseAnError'), [$t])
+      $this->fixture->handle($this, typeof($this)->getMethod('raiseAnError'), [$t])
     );
   }
 

--- a/src/test/php/webservices/rest/unittest/srv/RestContextTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/RestContextTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace webservices\rest\unittest\srv;
 
 use webservices\rest\TypeMarshaller;
-use lang\Object;
 use webservices\rest\srv\ExceptionMapper;
 use unittest\TestCase;
 use scriptlet\HttpScriptletRequest;
@@ -152,7 +151,7 @@ class RestContextTest extends TestCase {
 
   #[@test]
   public function handle_xmlfactory_annotated_method() {
-    $handler= newinstance('#[@webservice, @xmlfactory(element= "greeting")] lang.Object', [], '{
+    $handler= newinstance('#[@webservice, @xmlfactory(element= "greeting")] webservices.rest.unittest.srv.Handler', [], '{
       #[@webmethod, @xmlfactory(element = "book")]
       public function getBook() {
         return array("isbn" => "978-3-16-148410-0", "author" => "Test");
@@ -166,7 +165,7 @@ class RestContextTest extends TestCase {
 
   #[@test]
   public function handle_xmlfactory_annotated_class() {
-    $handler= newinstance('#[@webservice, @xmlfactory(element= "greeting")] lang.Object', [], '{
+    $handler= newinstance('#[@webservice, @xmlfactory(element= "greeting")] webservices.rest.unittest.srv.Handler', [], '{
       #[@webmethod]
       public function greet() { return "Test"; }
     }');
@@ -197,7 +196,7 @@ class RestContextTest extends TestCase {
 
   #[@test]
   public function constructor_injection() {
-    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_ConstructorInjection', 'lang.Object', [], '{
+    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_ConstructorInjection', 'webservices.rest.unittest.srv.Handler', [], '{
       protected $context;
       #[@inject(type = "webservices.rest.srv.RestContext")]
       public function __construct($context) { $this->context= $context; }
@@ -211,7 +210,7 @@ class RestContextTest extends TestCase {
 
   #[@test]
   public function typename_injection() {
-    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_TypeNameInjection', 'lang.Object', [], '{
+    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_TypeNameInjection', 'webservices.rest.unittest.srv.Handler', [], '{
       protected $context;
 
       /** @param webservices.rest.srv.RestContext context */
@@ -227,7 +226,7 @@ class RestContextTest extends TestCase {
 
   #[@test]
   public function typerestriction_injection() {
-    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_TypeRestrictionInjection', 'lang.Object', [], '{
+    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_TypeRestrictionInjection', 'webservices.rest.unittest.srv.Handler', [], '{
       protected $context;
 
       #[@inject]
@@ -244,7 +243,7 @@ class RestContextTest extends TestCase {
   public function setter_injection() {
     $prop= new \util\Properties('service.ini');
     \util\PropertyManager::getInstance()->register('service', $prop);
-    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_SetterInjection', 'lang.Object', [], '{
+    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_SetterInjection', 'webservices.rest.unittest.srv.Handler', [], '{
       public $prop;
       #[@inject(type = "util.Properties", name = "service")]
       public function setServiceConfig($prop) { $this->prop= $prop; }
@@ -257,7 +256,7 @@ class RestContextTest extends TestCase {
 
   #[@test]
   public function unnamed_logcategory_injection() {
-    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_UnnamedLogcategoryInjection', 'lang.Object', [], '{
+    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_UnnamedLogcategoryInjection', 'webservices.rest.unittest.srv.Handler', [], '{
       public $cat;
       #[@inject(type = "util.log.LogCategory")]
       public function setTrace($cat) { $this->cat= $cat; }
@@ -272,7 +271,7 @@ class RestContextTest extends TestCase {
 
   #[@test]
   public function named_logcategory_injection() {
-    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_NamedLogcategoryInjection', 'lang.Object', [], '{
+    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_NamedLogcategoryInjection', 'webservices.rest.unittest.srv.Handler', [], '{
       public $cat;
       #[@inject(type = "util.log.LogCategory", name = "test")]
       public function setTrace($cat) { $this->cat= $cat; }
@@ -286,7 +285,7 @@ class RestContextTest extends TestCase {
 
   #[@test, @expect(class = 'lang.reflect.TargetInvocationException', withMessage= '/InjectionError::setTrace/')]
   public function injection_error() {
-    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_InjectionError', 'lang.Object', [], '{
+    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_InjectionError', 'webservices.rest.unittest.srv.Handler', [], '{
       #[@inject(type = "util.log.LogCategory")]
       public function setTrace($cat) { throw new \lang\IllegalStateException("Test"); }
     }');
@@ -295,7 +294,7 @@ class RestContextTest extends TestCase {
 
   #[@test, @expect(class = 'lang.reflect.TargetInvocationException', withMessage= '/InstantiationError::<init>/')]
   public function instantiation_error() {
-    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_InstantiationError', 'lang.Object', [], '{
+    $class= \lang\ClassLoader::defineClass('AbstractRestRouterTest_InstantiationError', 'webservices.rest.unittest.srv.Handler', [], '{
       public function __construct() { throw new \lang\IllegalStateException("Test"); }
     }');
     $this->fixture->handlerInstanceFor($class);

--- a/src/test/php/webservices/rest/unittest/srv/RestRouteTest.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/RestRouteTest.class.php
@@ -17,7 +17,7 @@ class RestRouteTest extends TestCase {
    * 
    */
   public function setUp() {
-    $this->handler= $this->getClass();
+    $this->handler= typeof($this);
     $this->target= $this->handler->getMethod('fixtureTarget');
   }
 

--- a/src/test/php/webservices/rest/unittest/srv/fixture/Greeting.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/fixture/Greeting.class.php
@@ -5,7 +5,7 @@
  *
  * @see  xp://net.xp_framework.unittest.webservices.rest.srv.RestDefaultRouterTest
  */
-class Greeting extends \lang\Object {
+class Greeting {
   public $word;
   public $name;
 

--- a/src/test/php/webservices/rest/unittest/srv/fixture/GreetingHandler.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/fixture/GreetingHandler.class.php
@@ -10,7 +10,7 @@ use webservices\rest\srv\StreamingOutput;
  * @see  xp://net.xp_framework.unittest.webservices.rest.srv.RestDefaultRouterTest
  */
 #[@webservice, @xmlfactory(element= 'greeting')]
-  class GreetingHandler extends \lang\Object {
+  class GreetingHandler {
   protected $fixture= null;
 
   /**

--- a/src/test/php/webservices/rest/unittest/srv/fixture/ImplicitGreetingHandler.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/fixture/ImplicitGreetingHandler.class.php
@@ -8,7 +8,7 @@
  * @see  xp://net.xp_framework.unittest.webservices.rest.srv.RestDefaultRouterTest
  */
 #[@webservice(path= '/implicit/')]
-  class ImplicitGreetingHandler extends \lang\Object {
+  class ImplicitGreetingHandler {
   protected $fixture= null;
 
   /**

--- a/src/test/php/webservices/rest/unittest/srv/fixture/RaisesErrorFromConstructor.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/fixture/RaisesErrorFromConstructor.class.php
@@ -6,7 +6,7 @@
  * @see  xp://webservices.rest.unitest.RestContextTest
  */
 #[@webservice]
-class RaisesErrorFromConstructor extends \lang\Object {
+class RaisesErrorFromConstructor {
 
   /**
    * Constructor. Raises a `lang.Error`.

--- a/src/test/php/webservices/rest/unittest/srv/fixture/RaisesExceptionFromConstructor.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/fixture/RaisesExceptionFromConstructor.class.php
@@ -6,7 +6,7 @@
  * @see  xp://webservices.rest.unitest.RestContextTest
  */
 #[@webservice]
-class RaisesExceptionFromConstructor extends \lang\Object {
+class RaisesExceptionFromConstructor {
 
   /**
    * Constructor. Raises a `lang.IllegalStateException`.

--- a/src/test/php/webservices/rest/unittest/srv/fixture/RaisesFromMethod.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/fixture/RaisesFromMethod.class.php
@@ -6,7 +6,7 @@
  * @see  xp://webservices.rest.unitest.RestContextTest
  */
 #[@webservice]
-class RaisesFromMethod extends \lang\Object {
+class RaisesFromMethod {
 
   /**
    * Fixture. Raises a `lang.Error`.

--- a/src/test/php/webservices/rest/unittest/srv/fixture/Wallet.class.php
+++ b/src/test/php/webservices/rest/unittest/srv/fixture/Wallet.class.php
@@ -1,0 +1,30 @@
+<?php namespace webservices\rest\unittest\srv\fixture;
+
+use util\Money;
+use util\Objects;
+use lang\Value;
+
+class Wallet implements Value {
+  public $values= [];
+
+  public function __construct($values= []) {
+    $this->values= $values;
+  }
+
+  public function add(Money $m) {
+    $this->values[]= $m;
+    return $this;
+  }
+
+  public function toString() {
+    return nameof($this).'@'.Objects::stringOf($this->values);
+  }
+
+  public function hashCode() {
+    return 'W'.Objects::hashOf($this->values);
+  }
+
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->values, $value->values) : 1;
+  }
+}


### PR DESCRIPTION
This pull request makes this library compatible with XP9 and the following upcoming versions:

* [x] xp-framework/http [9.0](https://github.com/xp-framework/http/releases/tag/v9.0.0)+ 
* [x] xp-framework/xml [9.0](https://github.com/xp-framework/xml/releases/tag/v9.0.0)+ 
* [x] xp-framework/scriptlet [9.0](https://github.com/xp-framework/scriptlet/releases/tag/v9.0.0)+ 
* [x] xp-framework/logging [8.0](https://github.com/xp-framework/logging/releases/tag/v8.0.0)+
* [x] xp-framework/collections [8.0](https://github.com/xp-framework/collections/releases/tag/v8.0.0)+
* [x] xp-framework/networking [9.0](https://github.com/xp-framework/networking/releases/tag/v9.0.0)+ 
* [x] xp-framework/tokenize [8.0](https://github.com/xp-framework/tokenize/releases/tag/v8.0.0)+ 
* [x] xp-framework/unittest [9.0](https://github.com/xp-framework/unittest/releases/tag/v9.0.0)+  